### PR TITLE
Increase grpc-web stream timeout to 1hr

### DIFF
--- a/onos-gui/values.yaml
+++ b/onos-gui/values.yaml
@@ -209,6 +209,7 @@ Envoy:
                         - name: envoy.grpc_web
                         - name: envoy.cors
                         - name: envoy.router
+                      stream_idle_timeout: 3600s
         {{- end }}
         clusters:
         {{- range $key, $value := .Values.onosservices }}


### PR DESCRIPTION
The default is 5 minutes. Any stream query like ListNetworkChange will close after this timespan if there is no traffic on the stream