### PR TITLE
loading of ModelPlugins from docker image

### DIFF
--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -63,8 +63,10 @@ spec:
             - "-caPath=/etc/onos-config/certs/tls.cacrt"
             - "-keyPath=/etc/onos-config/certs/tls.key"
             - "-certPath=/etc/onos-config/certs/tls.crt"
-            {{- range $i, $plugin := .Values.plugins }}
-            - {{ printf "-modelPlugin=/usr/local/lib/%s" $plugin }}
+            {{- range $key, $plugin := .Values.plugins }}
+              {{- range $j, $v := $plugin.versions }}
+            - {{ printf "-modelPlugin=/usr/local/lib/shared/%s.so.%s" $key $v }}
+              {{- end }}
             {{- end }}
             {{- if .Values.topoEndpoint }}
             - {{ printf "-topoEndpoint=%s" .Values.topoEndpoint }}
@@ -92,6 +94,8 @@ spec:
             - name: secret
               mountPath: /etc/onos-config/certs
               readOnly: true
+            - name: shared-data
+              mountPath: /usr/local/lib/shared
           # Enable ptrace for debugging
           securityContext:
             {{- if .Values.debug }}
@@ -99,12 +103,30 @@ spec:
               add:
                 - SYS_PTRACE
             {{- end }}
-      # Mount test volumes
-      # TODO: This should be removed when stores are added!
+        # Load model plugins as side car containers
+        {{- range $key, $plugin := .Values.plugins }}
+          {{- range $j, $v := $plugin.versions }}
+        - name: {{ printf "config-model-%s-%s" $key $v | replace "." "-" }}
+          image: {{ printf "onosproject/config-model-%s-%s:%s" $key $v $.Values.image.tag }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          command:
+            - "/copylibandstay"
+          args:
+            - {{ printf "%s.so.%s" $key $v }}
+            - {{ printf "/usr/local/lib/%s.so.%s" $key $v }}
+            - "stayrunning"
+          volumeMounts:
+            - name: shared-data
+              mountPath: /usr/local/lib
+          {{- end }}
+        {{- end }}
+      # Mount volumes
       volumes:
         - name: secret
           secret:
             secretName: {{ template "onos-config.fullname" . }}-secret
+        - name: shared-data
+          emptyDir: {}
     {{- with .Values.nodeSelector }}
     nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -18,7 +18,17 @@ debug: false
 
 devices: []
 
-plugins: [devicesim.so.1.0.0, testdevice.so.1.0.0, testdevice.so.2.0.0, stratum.so.1.0.0]
+plugins:
+  devicesim:
+    versions:
+      - 1.0.0
+  stratum:
+    versions:
+      - 1.0.0
+  testdevice:
+    versions:
+      - 1.0.0
+      - 2.0.0
 
 # Variable to change to onos topo service endpoint for the default onos-topo:5150
 # topoEndpoint: onos-topo-classic:5150


### PR DESCRIPTION
This provides a method for loading model plugins from Docker images as sidecars to `onos-config`

When the plugin container is loaded it copies its `.so` file to a shared folder where `onos-config` can access it as a file and load it with `-modelPlugin`. 

This is the recommended way of sharing files between sidecar containers. See https://kubernetes.io/docs/tasks/access-application-cluster/communicate-containers-same-pod-shared-volume/

Currently I am generating the model plugin Docker image in https://github.com/onosproject/config-models/pull/1
but this creates a model plugin that's incompatible with `onos-config`. I will fix this and will try to merge this then.