### PR TITLE
Add Helm chart for TLA+ conformance monitoring

### DIFF
--- a/tlaplus-monitor/Chart.yaml
+++ b/tlaplus-monitor/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: tlaplus-monitor
+kubeVersion: ">=1.12.0"
+type: application
+version: 0.0.1
+appVersion: 1.0
+description: TLA+ Conformance Monitor
+keywords:
+  - monitoring
+  - verification
+home: https://onosproject.org
+maintainers:
+  - name: kuujo
+    email: jordan@opennetworking.org
+  - name: Adib Rastegarnia
+    email: adib@opennetworking.org

--- a/tlaplus-monitor/README.md
+++ b/tlaplus-monitor/README.md
@@ -1,0 +1,218 @@
+# TLA+ Conformance Monitor
+
+Provides a Helm chart that enables near-real time conformance monitoring with [TLA+].
+
+The conformance monitor uses the TLA+ specification language and the TLC model checker to evaluate
+system trace streams to detect violations of system safety properties. This chart can configure and
+run arbitrary TLA+ conformance monitoring specs and their dependencies.
+
+## Prerequisites
+
+The conformance monitor requires on an existing [Kafka] deployment from which to consume traces.
+
+To deploy Kafka using Helm, first add the incubator repository to your Helm configuration:
+
+```bash
+$ helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+```
+
+Define a `values.yaml` file for your Kafka cluster, configuring the topics to be used by the conformance monitor
+to consume traces and produce alerts:
+
+```yaml
+replicas: 1
+zookeeper:
+  replicaCount: 1
+topics:
+  - name: traces
+    partitions: 3
+    replicationFactor: 1
+  - name: alerts
+    partitions: 1
+    replicationFactor: 1
+```
+
+Then, install the `incubator/kafka` chart with the desired configuration overrides:
+
+```bash
+$ helm install kafka incubator/kafka --values values.yaml
+```
+
+The successful completion of the `kafka-config` pod indicates the Kafka brokers have completed startup and
+configured topics have been created.
+
+## Installation
+
+Once the Kafka cluster has been configured, this chart can be deployed to perform near real-time conformance
+monitoring on Kafka streams. The monitor uses [TLA+] specifications to evaluate traces received from Kafka,
+and invariants specified in the chart configuration can detect safety violations in the trace stream.
+
+Several artifacts are required to by the chart:
+* `model` - the name of the module to evaluate
+* `modules` - an array of TLA+ module files to mount to the monitor pod
+* `spec` - the specification to evaluate
+* `init` - the state initialization predicate (required if `spec` is not configured)
+* `next` - the next state relation (required if `spec` is not configured)
+
+Additional options can be used to specify invariants and other constraints on the model checker:
+* `invariants` - an array of invariants to check for each trace
+* `constants` - a mapping of constant values to assign to the model
+* `constraints` - an array of state constraints
+* `properties` - an array of model properties
+
+```bash
+$ helm install my-monitor --set modules={Cache.tla,CacheHistory.tla} --set model=Cache.tla --set config.spec=Spec --set config.invariants={TypeOK}
+```
+
+## Specifications
+
+The role of the conformance monitor is to track the system state over time and detect violations
+of safety guarantees by analyzing the system state. To do so, [TLA+] specifications are used to
+provide a formal model for state transitions and specify the invariants to which the system must
+conform.
+
+TLA+ specifications consist of one or more modules defined in `.tla` files. A module defines a set 
+of formulas for evaluating the state of the system. The specification provides a formula describing 
+the initial system state and its transitions:
+
+```
+---------------------------- MODULE MonotonicTrace --------------------------
+
+EXTENDS Naturals, Sequences
+
+\* A list of variables in the spec
+vars == <<...>>
+
+\* The init predicate describing the initial state of the system
+Init == ...
+
+\* The next state relation describing possible state transitions
+Next == ...
+
+\* The system specification describes the initial system state and next state relations
+Spec == Init /\ [][Next]_<<vars>>
+
+=============================================================================
+```
+
+Typically, the TLA+ model checker, TLC, computes and evaluates every state that can be reached
+by the spec according to its initial state and next state relation. Conformance monitoring specs
+operate on an infinite stream of traces, using the `KafkaConsume` operator to consume and check 
+traces in near-real time:
+
+```
+INSTANCE KafkaUtils
+
+\* The previous trace version
+VARIABLE prevVersion
+
+\* The current trace version
+VARIABLE nextVersion
+
+\* A list of variables in the spec
+vars == <<prevVersion, nextVersion>>
+
+\* Read a trace record from the Kafka stream and update the previous and next versions
+Read ==
+    LET record == KafkaConsume("traces")
+    IN
+       /\ PrintT(record)
+       /\ prevVersion' = nextVersion
+       /\ nextVersion' = record.version
+
+\* The init predicate describing the initial state of the system
+Init == 
+    /\ prevVersion = 0
+    /\ nextVersion = 0
+
+\* The next state relation describing possible state transitions
+Next ==
+    \/ Read
+    \/ UNCHANGED <<vars>>
+```
+
+The final component of a conformance spec is the invariant(s). Invariants are predicates
+that describe the properties of a well behaved (conforming) system. After each trace is
+consumed and processed from the Kafka stream, TLC will evaluate invariants to determine
+whether the system's state conforms to its safety properties:
+
+```
+\* An invariant verifying that the trace version is monotonically increasing
+TypeOK == prevVersion # 0 /\ nextVersion # 0 => prevVersion < nextVersion
+```
+
+In the event the invariant is violated by the system traces, the `KafkaProduce` operator
+can be used to publish an alert.
+
+```
+\* An invariant verifying that the trace version is monotonically increasing
+TypeOK == 
+    \/ prevVersion # 0 /\ nextVersion # 0 => prevVersion < nextVersion
+    \/ KafkaProduce("alerts", [msg         |-> "Invariant violated", 
+                               prevVersion |-> prevVersion,
+                               nextVersion |-> nextVersion])
+```
+
+With the initial state predicate, the next state relation, and the type invariants,
+a complete conformance monitoring spec can be compiled:
+
+```
+---------------------------- MODULE MonotonicTrace --------------------------
+
+EXTENDS Naturals, Sequences
+
+INSTANCE KafkaUtils
+
+\* The previous trace version
+VARIABLE prevVersion
+
+\* The current trace version
+VARIABLE nextVersion
+
+\* A list of variables in the spec
+vars == <<prevVersion, nextVersion>>
+
+\* An invariant verifying that the trace version is monotonically increasing
+TypeOK == 
+    \/ prevVersion # 0 /\ nextVersion # 0 => prevVersion < nextVersion
+    \/ KafkaProduce("alerts", [msg         |-> "Invariant violated", 
+                               prevVersion |-> prevVersion,
+                               nextVersion |-> nextVersion])
+
+\* Read a trace record from the Kafka stream and update the previous and next versions
+Read ==
+    LET record == KafkaConsume("traces")
+    IN
+       /\ PrintT(record)
+       /\ prevVersion' = nextVersion
+       /\ nextVersion' = record.version
+
+\* The init predicate describing the initial state of the system
+Init == 
+    /\ prevVersion = 0
+    /\ nextVersion = 0
+
+\* The next state relation describing possible state transitions
+Next ==
+    \/ Read
+    \/ UNCHANGED <<vars>>
+
+\* The system specification describes the initial system state and next state relations
+Spec == Init /\ [][Next]_<<vars>>
+
+=============================================================================
+```
+
+To deploy the specification for conformance monitoring, the chart must be configured to
+identify the specification `Spec` and its invariant `TypeOK`:
+
+```bash
+$ helm install my-monitor --set modules={MonotonicTrace.tla} --set model=MonotonicTrace.tla --set config.spec=Spec --set config.invariants={TypeOK}
+```
+
+The model will be initialized with the `prevVersion` and `nextVersion` set to `0`.
+As traces are pushed onto the Kafka stream, the model checker will `Read` the trace
+records, update the model state, and evaluate the invariant `TypeOK`.
+
+[TLA+]: https://lamport.azurewebsites.net/tla/tla.html
+[Kafka]: https://kafka.apache.org/

--- a/tlaplus-monitor/templates/_helpers.tpl
+++ b/tlaplus-monitor/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tlaplus-monitor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tlaplus-monitor.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tlaplus-monitor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "tlaplus-monitor.labels" -}}
+helm.sh/chart: {{ include "tlaplus-monitor.chart" . }}
+{{ include "tlaplus-monitor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tlaplus-monitor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tlaplus-monitor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+List join utility
+*/}}
+{{- define "tlaplus-monitor.join" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}

--- a/tlaplus-monitor/templates/configmap.yaml
+++ b/tlaplus-monitor/templates/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "tlaplus-monitor.fullname" . }}-modules
+  labels:
+    name: {{ template "tlaplus-monitor.fullname" . }}-modules
+    model: {{ .Values.model }}
+    app: {{ template "tlaplus-monitor.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  {{ base .Values.model | trimSuffix ".tla"  }}.cfg: |
+    {{ if .Values.config.spec }}
+    SPECIFICATION {{ .Values.config.spec }}
+    {{ end }}
+    {{ if .Values.config.init }}
+    INIT {{ .Values.config.init }}
+    {{ end }}
+    {{ if .Values.config.next }}
+    NEXT {{ .Values.config.next }}
+    {{ end }}
+    {{- range .Values.config.invariants }}
+    INVARIANT {{ . }}
+    {{- end }}
+    {{- range $key, $value := .Values.config.constants }}
+    CONSTANT {{ $key }}={{ $value }}
+    {{- end}}
+    {{- range .Values.config.constraints }}
+    CONSTRAINT {{ . }}
+    {{- end }}
+    {{- range .Values.config.properties }}
+    PROPERTY {{ . }}
+    {{- end }}
+  {{ $root := . }}
+  {{- range .Values.modules }}
+  {{ base . }}: '{{ $root.Files.Get . }}'
+  {{- end }}

--- a/tlaplus-monitor/templates/deployment.yaml
+++ b/tlaplus-monitor/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "tlaplus-monitor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: {{ template "tlaplus-monitor.fullname" . }}
+    model: {{ base .Values.model | quote }}
+    app: {{ template "tlaplus-monitor.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      model: {{ base .Values.model | quote }}
+  template:
+    metadata:
+      labels:
+        model: {{ base .Values.model | quote }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: onosproject/tlaplus-monitor:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - /opt/tlaplus/model/{{ .Values.model }}
+            - -metadir
+            - /opt/tlaplus/data
+            - -continue
+          env:
+            - name: KAFKA_GROUP
+              value: {{ template "tlaplus-monitor.fullname" . }}
+            - name: KAFKA_SERVERS
+              value: {{ include "tlaplus-monitor.join" .Values.kafka.servers }}
+          volumeMounts:
+            - name: models
+              mountPath: /opt/tlaplus/model
+              readOnly: true
+            - name: data
+              mountPath: /opt/tlaplus/data
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: models
+          configMap:
+            name: {{ template "tlaplus-monitor.fullname" . }}-modules
+        - name: data
+          emptyDir: {}

--- a/tlaplus-monitor/values.yaml
+++ b/tlaplus-monitor/values.yaml
@@ -1,0 +1,44 @@
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+annotations: {}
+
+image:
+  repository: onosproject/tlaplus-monitor
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+resources:
+  requests:
+    cpu: 0.5
+    memory: 512Mi
+
+# 'model' is the name of the model file to run
+model: ""
+
+# 'modules' is a list of module files to include. This should contain at least the 'model' file.
+modules: []
+
+# 'config' is the TLC configuration
+config:
+  # 'spec' is the specification expression
+  spec: Spec
+  # 'init' is the init predicate
+  init: ""
+  # 'next' is the next state relation
+  next: ""
+  # 'invariants' is an array of invariant names to check
+  invariants: []
+  # 'constants' is a mapping of constant names to values
+  constants: {}
+  # 'constraints' is an array of state constraints
+  constraints: []
+  # 'properties' is an array of model properties
+  properties: []
+
+# 'kafka' configures the monitor's Kafka connection
+kafka:
+  # 'servers' is the list of Kafka servers to which to connect
+  servers: ["kafka-headless:9092"]


### PR DESCRIPTION
This PR adds a new Helm chart to do real-time conformance monitoring with TLA+ specs using the TLC model checker. Conformance monitoring is done by consuming traces from a Kafka topic and publishing alerts (invariant violations) to another Kafka topic. Applications must write traces to a Kafka topic to be consumed by the conformance monitors.

More info in the README