### PR TITLE
Allow quotations inside TLA+ modules

### DIFF
--- a/tlaplus-monitor/templates/configmap.yaml
+++ b/tlaplus-monitor/templates/configmap.yaml
@@ -34,5 +34,6 @@ data:
     {{- end }}
   {{ $root := . }}
   {{- range .Values.modules }}
-  {{ base . }}: '{{ $root.Files.Get . }}'
+  {{ base . }}: |-
+{{ $root.Files.Get . | indent 4 }}
   {{- end }}


### PR DESCRIPTION
Fix a bug that causes parsing issues when `'` is present in TLA+ specs