### PR TITLE
Update TLA+ monitoring Helm chart to use new flags

### DIFF
--- a/tlaplus-monitor/templates/deployment.yaml
+++ b/tlaplus-monitor/templates/deployment.yaml
@@ -32,12 +32,11 @@ spec:
             - /opt/tlaplus/model/{{ .Values.model }}
             - -metadir
             - /opt/tlaplus/data
-            - -continue
-          env:
-            - name: KAFKA_GROUP
-              value: {{ template "tlaplus-monitor.fullname" . }}
-            - name: KAFKA_SERVERS
-              value: {{ include "tlaplus-monitor.join" .Values.kafka.servers }}
+            - -monitor
+            - -trace
+            - "kafka://{{ .Values.kafka.service }}:{{ .Values.kafka.port }}/{{ .Values.kafka.topics.traces }}"
+            - -alert
+            - "kafka://{{ .Values.kafka.service }}:{{ .Values.kafka.port }}/{{ .Values.kafka.topics.alerts }}"
           volumeMounts:
             - name: models
               mountPath: /opt/tlaplus/model

--- a/tlaplus-monitor/values.yaml
+++ b/tlaplus-monitor/values.yaml
@@ -40,5 +40,13 @@ config:
 
 # 'kafka' configures the monitor's Kafka connection
 kafka:
-  # 'servers' is the list of Kafka servers to which to connect
-  servers: ["kafka-headless:9092"]
+  # 'service' is the Kafka service to which to connect
+  service: kafka-headless
+  # 'port' is the Kafka port
+  port: 9092
+  # 'topics' is the Kafka topic configuration
+  topics:
+    # 'trace' is the name of the traces topic
+    traces: traces
+    # 'alerts' is the name of the alerts topic
+    alerts: alerts


### PR DESCRIPTION
This PR updates the TLA+ monitoring Helm chart to use new source and sink configurations supported by https://github.com/onosproject/tlaplus-monitor/pull/3

Conformance monitoring specs can now be decoupled from the trace source and alert sink. Sources and sinks are configured by the Helm chart.