### PR TITLE
Small bugfix and add NodePort to directly access Web GUI

### DIFF
--- a/sd-ran-gui/templates/service.yaml
+++ b/sd-ran-gui/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,7 +14,7 @@ spec:
   selector:
     name: {{ template "sd-ran-gui.fullname" . }}
     app: onos
-    type: gui
+    type: sdran
     resource: {{ template "sd-ran-gui.fullname" . }}
     {{- include "sd-ran-gui.selectorLabels" . | nindent 4 }}
   ports:
@@ -24,3 +25,27 @@ spec:
       port: {{ $value.proxy }}
     {{- end }}
 
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "sd-ran-gui.fullname" . }}-external
+  labels:
+    app: {{ template "sd-ran-gui.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "sd-ran-gui.labels" . | nindent 4 }}
+spec:
+  type: NodePort
+  selector:
+    name: {{ template "sd-ran-gui.fullname" . }}
+    app: onos
+    type: sdran
+    resource: {{ template "sd-ran-gui.fullname" . }}
+    {{- include "sd-ran-gui.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: web
+      port: 80
+      nodePort: 33080
+      protocol: TCP


### PR DESCRIPTION
Small bugfix: Selector in Services.yaml has different `type` value compared with the `type` value in deployemet.yaml in sd-ran-gui.

To directly access Web GUI, I just added NodePort services. With that, we don't need to manually assign accessible IP address (for LoadBalancer) or manually set a port forwarding.