### PR TITLE
Add services to communicate with Prometheus

### DIFF
--- a/onos-ric-ho/templates/service.yaml
+++ b/onos-ric-ho/templates/service.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "onos-ric-ho.fullname" . }}
+  labels:
+    app: {{ template "onos-ric-ho.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "onos-ric-ho.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    name: {{ template "onos-ric-ho.fullname" . }}
+    app: onos
+    type: ho
+    resource: {{ template "onos-ric-ho.fullname" . }}
+    {{- include "onos-ric-ho.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: exporter
+      port: 7001
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "onos-ric-ho.fullname" . }}-external
+  labels:
+    app: {{ template "onos-ric-ho.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "onos-ric-ho.labels" . | nindent 4 }}
+spec:
+  type: NodePort
+  selector:
+    name: {{ template "onos-ric-ho.fullname" . }}
+    app: onos
+    type: ho
+    resource: {{ template "onos-ric-ho.fullname" . }}
+    {{- include "onos-ric-ho.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: exporter
+      port: 7001
+      nodePort: 33701
+      protocol: TCP


### PR DESCRIPTION
Add two K8s services to connect HO App with Prometheus.
One service is Cluster IP exposing 7001 port which Prometheus can access directly through domain name. The other service is NodePort exposing 33701 port for debugging. I will remove NodePort later, or make it as optional.