### PR TITLE
Added a namespace env to ran-simulator

### DIFF
--- a/ran-simulator/templates/deployment.yaml
+++ b/ran-simulator/templates/deployment.yaml
@@ -33,6 +33,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           args:
             - "-caPath=/etc/ran-simulator/certs/tls.cacrt"
             - "-keyPath=/etc/ran-simulator/certs/tls.key"

--- a/ran-simulator/templates/service.yaml
+++ b/ran-simulator/templates/service.yaml
@@ -17,7 +17,8 @@ spec:
     resource: {{ template "ran-simulator.fullname" . }}
     {{- include "ran-simulator.selectorLabels" . | nindent 4 }}
   ports:
-    - name: grpc
+    - name: trafficsim
       port: 5150
     - name: exporter
       port: 9090
+# Other ports will be added here dynamically by the application for E2 interface


### PR DESCRIPTION
The recent change to `ran-simulator`
https://github.com/onosproject/ran-simulator/pull/68
needs this env parameter - will add it to onit too