### PR TITLE
Add Helm chart for deploying the Atomix controller

### DIFF
--- a/atomix-controller/Chart.yaml
+++ b/atomix-controller/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: atomix-controller
+description: Atomix Controller
+kubeVersion: ">=1.12.0"
+type: application
+version: 0.1.0
+appVersion: 1.0
+keywords:
+  - atomix
+home: https://atomix.io
+maintainers:
+  - name: kuujo
+    email: jordan@opennetworking.org

--- a/atomix-controller/crds/cluster.yaml
+++ b/atomix-controller/crds/cluster.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusters.cloud.atomix.io
+spec:
+  group: cloud.atomix.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  version: v1beta1
+  subresources:
+    status: {}

--- a/atomix-controller/crds/database.yaml
+++ b/atomix-controller/crds/database.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: databases.cloud.atomix.io
+spec:
+  group: cloud.atomix.io
+  names:
+    kind: Database
+    listKind: DatabaseList
+    plural: databases
+    singular: database
+  scope: Namespaced
+  version: v1beta1
+  subresources:
+    status: {}

--- a/atomix-controller/crds/partition.yaml
+++ b/atomix-controller/crds/partition.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: partitions.cloud.atomix.io
+spec:
+  group: cloud.atomix.io
+  names:
+    kind: Partition
+    listKind: PartitionList
+    plural: partitions
+    singular: partition
+  scope: Namespaced
+  version: v1beta1
+  subresources:
+    status: {}

--- a/atomix-controller/templates/clusterrole.yaml
+++ b/atomix-controller/templates/clusterrole.yaml
@@ -1,0 +1,41 @@
+{{- if not .Values.namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - cloud.atomix.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+{{- end }}

--- a/atomix-controller/templates/clusterrolebinding.yaml
+++ b/atomix-controller/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.namespace }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/atomix-controller/templates/deployment.yaml
+++ b/atomix-controller/templates/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: {{ .Release.Name }}
+          # Replace this with the built image name
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          ports:
+            - containerPort: 60000
+              name: metrics
+            - containerPort: 5679
+              name: control
+          {{- if .Values.namespace }}
+          args:
+            - {{ .Values.namespace }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/atomix-controller-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: CONTROLLER_NAME
+              value: {{ .Release.Name }}
+            - name: CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/atomix-controller/templates/role.yaml
+++ b/atomix-controller/templates/role.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ .Release.Name }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - cloud.atomix.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+{{- end }}

--- a/atomix-controller/templates/rolebinding.yaml
+++ b/atomix-controller/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.namespace }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/atomix-controller/templates/service.yaml
+++ b/atomix-controller/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    name: {{ .Release.Name }}
+spec:
+  selector:
+    name: {{ .Release.Name }}
+  ports:
+    - name: control
+      port: 5679

--- a/atomix-controller/templates/serviceaccount.yaml
+++ b/atomix-controller/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}

--- a/atomix-controller/values.yaml
+++ b/atomix-controller/values.yaml
@@ -1,0 +1,7 @@
+replicas: 1
+namespace: ""
+image:
+  repository: atomix/kubernetes-controller
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []


### PR DESCRIPTION
This PR adds a Helm chart for the Atomi controller. The chart sets up both the Atomix custom resources and deploys a controller for them. The chart supports deployment of the controller to manage resources in all namespaces or in a specific namespace, setting up permissions according to the configuration.