### PR TITLE
Use 'scope' value to configure Atomix controller scope

### DIFF
--- a/atomix-controller/README.md
+++ b/atomix-controller/README.md
@@ -1,6 +1,21 @@
 ## Atomix Controller
 
 Provides a [Helm] chart for deploying the [Atomix Controller] on [Kubernetes].
-See the [documentation](https://github.com/onosproject/simulators/blob/master/docs/deployment.md) for more info.
 
+To install the chart, run `helm install` from the root:
+
+```bash
+helm install atomix-controller .
+```
+
+By default, the controller is deployed at the cluster scope, allowing it to control all `cloud.atomix.io` `Database`, 
+`Cluster`, and `Partition` resources in the cluster. To deploy the controller within the scope of the chart's namespace,
+set `scope` to `Namespace`:
+
+```bash
+helm install atomix-controller . --set scope=Namespace
+```
+
+[Helm]: https://helm.sh/
+[Kubernetes]: https://kubernetes.io
 [Atomix Controller]: https://github.com/atomix/kubernetes-controller

--- a/atomix-controller/README.md
+++ b/atomix-controller/README.md
@@ -1,0 +1,6 @@
+## Atomix Controller
+
+Provides a [Helm] chart for deploying the [Atomix Controller] on [Kubernetes].
+See the [documentation](https://github.com/onosproject/simulators/blob/master/docs/deployment.md) for more info.
+
+[Atomix Controller]: https://github.com/atomix/kubernetes-controller

--- a/atomix-controller/templates/clusterrole.yaml
+++ b/atomix-controller/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.namespace }}
+{{- if eq (.Values.scope | lower) "cluster" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/atomix-controller/templates/clusterrolebinding.yaml
+++ b/atomix-controller/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.namespace }}
+{{- if eq (.Values.scope | lower) "cluster" }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -6,6 +6,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}

--- a/atomix-controller/templates/deployment.yaml
+++ b/atomix-controller/templates/deployment.yaml
@@ -22,9 +22,9 @@ spec:
               name: metrics
             - containerPort: 5679
               name: control
-          {{- if .Values.namespace }}
+          {{- if eq (.Values.scope | lower) "namespace" }}
           args:
-            - {{ .Values.namespace }}
+            - {{ .Release.Namespace }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           readinessProbe:

--- a/atomix-controller/templates/role.yaml
+++ b/atomix-controller/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.namespace }}
+{{- if eq (.Values.scope | lower) "namespace" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/atomix-controller/templates/rolebinding.yaml
+++ b/atomix-controller/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.namespace }}
+{{- if eq (.Values.scope | lower) "namespace" }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/atomix-controller/templates/serviceaccount.yaml
+++ b/atomix-controller/templates/serviceaccount.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}

--- a/atomix-controller/values.yaml
+++ b/atomix-controller/values.yaml
@@ -1,5 +1,5 @@
 replicas: 1
-namespace: ""
+scope: Cluster
 image:
   repository: atomix/kubernetes-controller
   tag: latest


### PR DESCRIPTION
This PR fixes a bug in the `atomix-controller` chart that did not correctly configure cluster role bindings when cluster scoped. Rather than using a `namespace` value, when the chart is configured with `scope=Cluster` it's deployed at the cluster scope, and when it's configured with `scope=Namespace` it's deployed at the namespace scope (controlling only resources within the given namespace).