### PR TITLE
Support configuration files in ONOS services

### DIFF
--- a/onos-config/templates/configmap.yaml
+++ b/onos-config/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "onos-config.fullname" . }}-config
+  labels:
+    app: {{ template "onos-config.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.yaml:
+{{ toYaml .Values.config | indent 4 }}

--- a/onos-config/templates/configmap.yaml
+++ b/onos-config/templates/configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  config.yaml:
+  onos.yaml: |-
 {{ toYaml .Values.config | indent 4 }}

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -60,9 +60,9 @@ spec:
             - name: ATOMIX_NAMESPACE
               value: {{ .Release.Namespace }}
           args:
-            - "-caPath=/etc/onos-config/certs/tls.cacrt"
-            - "-keyPath=/etc/onos-config/certs/tls.key"
-            - "-certPath=/etc/onos-config/certs/tls.crt"
+            - "-caPath=/etc/onos/certs/tls.cacrt"
+            - "-keyPath=/etc/onos/certs/tls.key"
+            - "-certPath=/etc/onos/certs/tls.crt"
             {{- range $key, $plugin := .Values.plugins }}
               {{- range $j, $v := $plugin.versions }}
             - {{ printf "-modelPlugin=/usr/local/lib/shared/%s.so.%s" $key $v }}
@@ -91,8 +91,11 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
+            - name: config
+              mountPath: /etc/onos/config
+              readOnly: true
             - name: secret
-              mountPath: /etc/onos-config/certs
+              mountPath: /etc/onos/certs
               readOnly: true
             - name: shared-data
               mountPath: /usr/local/lib/shared
@@ -122,6 +125,9 @@ spec:
         {{- end }}
       # Mount volumes
       volumes:
+        - name: config
+          configMap:
+            name: {{ template "onos-config.fullname" . }}-config
         - name: secret
           secret:
             secretName: {{ template "onos-config.fullname" . }}-secret

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -57,3 +57,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+config: {}

--- a/onos-ric/templates/configmap.yaml
+++ b/onos-ric/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "onos-ric.fullname" . }}-config
+  labels:
+    app: {{ template "onos-ric.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.yaml:
+{{ toYaml .Values.config | indent 4 }}

--- a/onos-ric/templates/configmap.yaml
+++ b/onos-ric/templates/configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  config.yaml:
+  onos.yaml: |-
 {{ toYaml .Values.config | indent 4 }}

--- a/onos-ric/templates/deployment.yaml
+++ b/onos-ric/templates/deployment.yaml
@@ -54,9 +54,9 @@ spec:
             - name: ATOMIX_NAMESPACE
               value: {{ .Release.Namespace }}
           args:
-            - "-caPath=/etc/onos-ric/certs/tls.cacrt"
-            - "-keyPath=/etc/onos-ric/certs/tls.key"
-            - "-certPath=/etc/onos-ric/certs/tls.crt"
+            - "-caPath=/etc/onos/certs/tls.cacrt"
+            - "-keyPath=/etc/onos/certs/tls.key"
+            - "-certPath=/etc/onos/certs/tls.crt"
           ports:
             - name: grpc
               containerPort: 5150
@@ -76,9 +76,14 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
-            - name: secret
-              mountPath: /etc/onos-ric/certs
+            - name: config
+              mountPath: /etc/onos/config
               readOnly: true
+            - name: secret
+              mountPath: /etc/onos/certs
+              readOnly: true
+            - name: shared-data
+              mountPath: /usr/local/lib/shared
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Enable ptrace for debugging
@@ -89,6 +94,9 @@ spec:
                 - SYS_PTRACE
             {{- end }}
       volumes:
+        - name: config
+          configMap:
+            name: {{ template "onos-ric.fullname" . }}-config
         - name: secret
           secret:
             secretName: {{ template "onos-ric.fullname" . }}-secret

--- a/onos-ric/templates/deployment.yaml
+++ b/onos-ric/templates/deployment.yaml
@@ -82,8 +82,6 @@ spec:
             - name: secret
               mountPath: /etc/onos/certs
               readOnly: true
-            - name: shared-data
-              mountPath: /usr/local/lib/shared
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Enable ptrace for debugging

--- a/onos-ric/values.yaml
+++ b/onos-ric/values.yaml
@@ -47,3 +47,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+config: {}

--- a/onos-topo/templates/configmap.yaml
+++ b/onos-topo/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "onos-ric.fullname" . }}-config
+  labels:
+    app: {{ template "onos-ric.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  config.yaml:
+{{ toYaml .Values.config | indent 4 }}

--- a/onos-topo/templates/configmap.yaml
+++ b/onos-topo/templates/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "onos-ric.fullname" . }}-config
+  name: {{ template "onos-topo.fullname" . }}-config
   labels:
-    app: {{ template "onos-ric.fullname" . }}
+    app: {{ template "onos-topo.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  config.yaml:
+  onos.yaml: |-
 {{ toYaml .Values.config | indent 4 }}

--- a/onos-topo/templates/deployment.yaml
+++ b/onos-topo/templates/deployment.yaml
@@ -85,8 +85,6 @@ spec:
             - name: secret
               mountPath: /etc/onos/certs
               readOnly: true
-            - name: shared-data
-              mountPath: /usr/local/lib/shared
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Enable ptrace for debugging

--- a/onos-topo/templates/deployment.yaml
+++ b/onos-topo/templates/deployment.yaml
@@ -57,9 +57,9 @@ spec:
             - name: ATOMIX_NAMESPACE
               value: {{ .Release.Namespace }}
           args:
-            - "-caPath=/etc/onos-topo/certs/tls.cacrt"
-            - "-keyPath=/etc/onos-topo/certs/tls.key"
-            - "-certPath=/etc/onos-topo/certs/tls.crt"
+            - "-caPath=/etc/onos/certs/tls.cacrt"
+            - "-keyPath=/etc/onos/certs/tls.key"
+            - "-certPath=/etc/onos/certs/tls.crt"
           ports:
             - name: grpc
               containerPort: 5150
@@ -79,9 +79,14 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           volumeMounts:
-            - name: secret
-              mountPath: /etc/onos-topo/certs
+            - name: config
+              mountPath: /etc/onos/config
               readOnly: true
+            - name: secret
+              mountPath: /etc/onos/certs
+              readOnly: true
+            - name: shared-data
+              mountPath: /usr/local/lib/shared
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Enable ptrace for debugging
@@ -92,6 +97,9 @@ spec:
                 - SYS_PTRACE
             {{- end }}
       volumes:
+        - name: config
+          configMap:
+            name: {{ template "onos-topo.fullname" . }}-config
         - name: secret
           secret:
             secretName: {{ template "onos-topo.fullname" . }}-secret

--- a/onos-topo/values.yaml
+++ b/onos-topo/values.yaml
@@ -40,3 +40,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+config: {}


### PR DESCRIPTION
This PR adds initial support for more complex configuration of ONOS services using configuration files. Each service has a new `config` value which is an arbitrary YAML struct defined by the service. The `config` is used to populate a `ConfigMap` which is mounted to the service and can be read using the [onos-lib-go configuration functions](https://github.com/onosproject/onos-lib-go/pull/25).