### PR TITLE
Adding redis proxy helm chart

### DIFF
--- a/redis-proxy/.helmignore
+++ b/redis-proxy/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/redis-proxy/Chart.yaml
+++ b/redis-proxy/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: redis-proxy
+description: A Helm chart for redis proxy
+
+type: application
+version: 0.0.1
+appVersion: 1.0
+keywords:
+  - redis
+  - atomix
+home: https://onosproject.org
+maintainers:
+  - name: kuujo
+    email: jordan@opennetworking.org
+  - name: Adib
+    email: adib@opennetworking.org

--- a/redis-proxy/templates/_helpers.tpl
+++ b/redis-proxy/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redis-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redis-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis-proxy.labels" -}}
+helm.sh/chart: {{ include "redis-proxy.chart" . }}
+{{ include "redis-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redis-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redis-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "redis-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/redis-proxy/templates/database.yaml
+++ b/redis-proxy/templates/database.yaml
@@ -1,0 +1,37 @@
+apiVersion: cloud.atomix.io/v1beta1
+kind: Database
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusters: {{.Values.clusters}}
+  template:
+    spec:
+      partitions: {{ .Values.partitions}}
+      proxy:
+        image: {{ .Values.proxy.repository }}:{{ .Values.proxy.tag }}
+        livenessProbe:
+          tcpSocket:
+            port: 5678
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      backend:
+        image: {{ .Values.backend.repository }}:{{ .Values.backend.tag }}
+        replicas: {{.Values.backend.replicaCount}}
+        livenessProbe:
+          tcpSocket:
+            port: 6379
+            initialDelaySeconds: 15
+            periodSeconds: 20
+        readinessProbe:
+          exec:
+            command:
+              - redis-cli
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+

--- a/redis-proxy/values.yaml
+++ b/redis-proxy/values.yaml
@@ -1,0 +1,15 @@
+clusters: 1
+partitions: 3
+
+proxy:
+  repository: atomix/redis-proxy
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+backend:
+  repository: redis
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+  replicaCount: 1


### PR DESCRIPTION
@kuujo 
I think for deploying redis proxy and testing (e.g. benchmarks), we need to have a helm chart for that. I am not sure, we should put it here or in atomix repo. I opened it for now to make a decision on that. 