### PR TITLE
Add cache database to onos-ric chart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.13
 
 require (
 	github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
-	github.com/onosproject/helmit v0.0.0-20200327194858-83f4463259da
+	github.com/onosproject/helmit v0.0.0-20200407154219-01143f65f143
+	github.com/onosproject/onos-ric v0.0.0-20200225182040-dcf370614b8e // indirect
+	github.com/renstrom/dedent v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/tools v0.0.0-20200313205530-4303120df7d8 // indirect
 	k8s.io/client-go v0.17.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,7 @@ github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
@@ -373,6 +374,7 @@ github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:Fecb
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xCzHAvxcr8HZnzsqU6ILg/0NiiE=
+github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -479,6 +481,8 @@ github.com/onosproject/helmit v0.0.0-20200327190752-61ce6a2b5fd4 h1:NYFZUkHRr/PI
 github.com/onosproject/helmit v0.0.0-20200327190752-61ce6a2b5fd4/go.mod h1:n5Cx+l/S/d+V3DStbpfbo16eGeZ/G3Nbl7u2nY4Ofxc=
 github.com/onosproject/helmit v0.0.0-20200327194858-83f4463259da h1:ynFY+Ya4mfbbTByA5tb+vRbQlD9xYUhdVVHWj2GGCOQ=
 github.com/onosproject/helmit v0.0.0-20200327194858-83f4463259da/go.mod h1:n5Cx+l/S/d+V3DStbpfbo16eGeZ/G3Nbl7u2nY4Ofxc=
+github.com/onosproject/helmit v0.0.0-20200407154219-01143f65f143 h1:QdQ6HdDVqZFz7jAaog0gx6RHFqFetGruNOpWwHregd4=
+github.com/onosproject/helmit v0.0.0-20200407154219-01143f65f143/go.mod h1:GwfwgPCBykeIOQJnii780T7J114+s4DLP8D/HUTdflk=
 github.com/onosproject/onos-cli v0.0.0-20200205222355-b174234b2ffa/go.mod h1:aUcsRKvZxiJOoT1KCUgp4iiDe71pvawPqPrXWoPmKjI=
 github.com/onosproject/onos-config v0.0.0-20191116095118-2ca4b5f98ae2/go.mod h1:KqXDEuf9d/uiHCL1iso0s8j3UUofZjCHUhs5pVWwJ0E=
 github.com/onosproject/onos-config v0.0.0-20200124182344-6c3f5eb1e6ed/go.mod h1:rQfBju27qOGvL7Qtvxo6H9TlvU0oEw91emQzS14hmnE=
@@ -948,6 +952,7 @@ modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/letsencrypt v0.0.3/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
 sigs.k8s.io/controller-runtime v0.1.8/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
 sigs.k8s.io/controller-runtime v0.1.12 h1:ovDq28E64PeY1yR+6H7DthakIC09soiDCrKvfP2tPYo=
 sigs.k8s.io/controller-runtime v0.1.12/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=

--- a/onos-ric/templates/cache.yaml
+++ b/onos-ric/templates/cache.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.store.cache.enabled }}
+apiVersion: cloud.atomix.io/v1beta1
+kind: Database
+metadata:
+  {{- if .Values.store.cache.database }}
+  name: {{ .Values.store.cache.database }}
+  {{- else }}
+  name: {{ template "onos-ric.fullname" . }}-cache
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusters: {{ .Values.store.cache.clusters }}
+  template:
+    spec:
+      partitions: {{ .Values.store.cache.partitions }}
+      backend:
+        image: {{ .Values.store.cache.backend.image }}
+{{- end }}

--- a/onos-ric/templates/configmap.yaml
+++ b/onos-ric/templates/configmap.yaml
@@ -14,8 +14,13 @@ data:
       namespace: {{ .Release.Namespace }}
       scope: {{ template "onos-ric.fullname" . }}
       databases:
+        {{- if .Values.store.cache.database }}
+        cache: {{ .Values.store.cache.database }}
+        {{- else }}
+        cache: {{ template "onos-ric.fullname" . }}-cache
+        {{- end }}
         {{- if .Values.store.consensus.database }}
-        consensus: {{ .Values.store.database }}
+        consensus: {{ .Values.store.consensus.database }}
         {{- else }}
         consensus: {{ template "onos-ric.fullname" . }}-consensus
         {{- end }}

--- a/onos-ric/templates/consensus.yaml
+++ b/onos-ric/templates/consensus.yaml
@@ -2,8 +2,8 @@
 apiVersion: cloud.atomix.io/v1beta1
 kind: Database
 metadata:
-  {{- if .Values.store.database }}
-  name: {{ .Values.store.database }}
+  {{- if .Values.store.consensus.database }}
+  name: {{ .Values.store.consensus.database }}
   {{- else }}
   name: {{ template "onos-ric.fullname" . }}-consensus
   {{- end }}

--- a/onos-ric/values.yaml
+++ b/onos-ric/values.yaml
@@ -21,6 +21,13 @@ enableMetrics: false
 
 store:
   controller: "atomix-controller.kube-system.svc.cluster.local:5679"
+  cache:
+    enabled: true
+    database: ""
+    partitions: 1
+    clusters: 1
+    backend:
+      image: atomix/local-replica:latest
   consensus:
     enabled: true
     database: ""


### PR DESCRIPTION
This PR separates the databases into two separate databases with two different consistency models. The `consensus` database is used for mastership election and related functions. The `cache` database is used to store messages.