### PR TITLE
Add script for releasing Helm charts to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+build/release
 build/_output

--- a/build/bin/release
+++ b/build/bin/release
@@ -18,7 +18,7 @@ token=${GITHUB_TOKEN}
 rm -rf build/release
 
 # Create a fresh clone of the repository
-git clone --branch master git@github.com:onosproject/onos-helm-charts.git build/release
+git clone --branch master git@github.com:$owner/$repo.git build/release
 
 cd build/release
 

--- a/build/bin/release
+++ b/build/bin/release
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [ "$#" -lt "1" ]; then
+    echo "must specify chart directory"
+    exit 1
+fi
+
+set -x
+
+chart=$1
+
+rm -r build/release
+
+branch=$(git branch --show-current)
+
+# Package the Helm chart
+helm package $chart --destination build/release
+
+# Upload the Helm chart release
+cr upload \
+    --git-base-url https://api.github.com/ \
+    --git-upload-url https://uploads.github.com/ \
+    --owner onosproject \
+    --git-repo onos-helm-charts \
+    --package-path build/release
+
+# Update the repository index
+cr index \
+    --index-path build/release/index.yaml \
+    --git-base-url https://api.github.com/ \
+    --git-upload-url https://uploads.github.com/ \
+    --owner onosproject \
+    --git-repo onos-helm-charts \
+    --charts-repo https://onosproject.github.io/onos-helm-charts \
+    --package-path build/release
+
+# Switch to the gh-pages branch and commit the updated index.yaml
+git checkout gh-pages
+mv build/release/index.yaml index.yaml
+git add index.yaml
+git commit -a -m "Add $chart release to index.yaml"
+git push origin gh-pages
+
+git checkout $branch

--- a/build/bin/release
+++ b/build/bin/release
@@ -44,7 +44,8 @@ cr index \
     --token $token
 
 # Commit the updated index.yaml
-git commit -a -m "Add $chart release to index.yaml"
+git add index.yaml
+git commit -m "Add $chart release to index.yaml" index.yaml
 git push $remote gh-pages
 
 git checkout $branch

--- a/build/bin/release
+++ b/build/bin/release
@@ -10,16 +10,20 @@ set -e
 
 chart=$1
 
-rm -rf build/release
-
 owner=${GITHUB_USER:-onosproject}
 repo=${GITHUB_REPO:-onos-helm-charts}
 remote=${GIT_REMOTE:-origin}
 token=${GITHUB_TOKEN}
-branch=$(git branch --show-current)
+
+rm -rf build/release
+
+# Create a fresh clone of the repository
+git clone --branch master git@github.com:onosproject/onos-helm-charts.git build/release
+
+cd build/release
 
 # Package the Helm chart
-helm package $chart --destination build/release
+helm package $chart --destination package
 
 # Upload the Helm chart release
 cr upload \
@@ -27,7 +31,7 @@ cr upload \
     --git-upload-url https://uploads.github.com/ \
     --owner $owner \
     --git-repo $repo \
-    --package-path build/release \
+    --package-path package \
     --token $token
 
 # Switch to the gh-pages branch
@@ -41,7 +45,7 @@ cr index \
     --owner $owner \
     --git-repo $repo \
     --charts-repo https://$owner.github.io/$repo \
-    --package-path build/release \
+    --package-path package \
     --token $token
 
 # Commit the updated index.yaml
@@ -49,4 +53,8 @@ git add index.yaml
 git commit -m "Add $chart release to index.yaml" index.yaml
 git push $remote gh-pages
 
-git checkout $branch
+git checkout master
+
+cd ../..
+
+rm -rf build/release

--- a/build/bin/release
+++ b/build/bin/release
@@ -14,6 +14,7 @@ rm -r build/release
 owner=${GITHUB_USER:-onosproject}
 repo=${GITHUB_REPO:-onos-helm-charts}
 remote=${GIT_REMOTE:-origin}
+token=${GITHUB_TOKEN}
 branch=$(git branch --show-current)
 
 # Package the Helm chart
@@ -25,7 +26,8 @@ cr upload \
     --git-upload-url https://uploads.github.com/ \
     --owner $owner \
     --git-repo $repo \
-    --package-path build/release
+    --package-path build/release \
+    --token $token
 
 # Switch to the gh-pages branch
 git checkout gh-pages
@@ -38,7 +40,8 @@ cr index \
     --owner $owner \
     --git-repo $repo \
     --charts-repo https://$owner.github.io/$repo \
-    --package-path build/release
+    --package-path build/release \
+    --token $token
 
 # Commit the updated index.yaml
 git commit -a -m "Add $chart release to index.yaml"

--- a/build/bin/release
+++ b/build/bin/release
@@ -26,8 +26,6 @@ helm package $chart --destination package
 
 # Upload the Helm chart release
 cr upload \
-    --git-base-url https://api.github.com/ \
-    --git-upload-url https://uploads.github.com/ \
     --owner $owner \
     --git-repo $repo \
     --package-path package \
@@ -39,8 +37,6 @@ git checkout gh-pages
 # Update the repository index
 cr index \
     --index-path index.yaml \
-    --git-base-url https://api.github.com/ \
-    --git-upload-url https://uploads.github.com/ \
     --owner $owner \
     --git-repo $repo \
     --charts-repo https://$owner.github.io/$repo \

--- a/build/bin/release
+++ b/build/bin/release
@@ -12,7 +12,6 @@ chart=$1
 
 owner=${GITHUB_USER:-onosproject}
 repo=${GITHUB_REPO:-onos-helm-charts}
-remote=${GIT_REMOTE:-origin}
 token=${GITHUB_TOKEN}
 
 rm -rf build/release
@@ -51,7 +50,7 @@ cr index \
 # Commit the updated index.yaml
 git add index.yaml
 git commit -m "Add $chart release to index.yaml" index.yaml
-git push $remote gh-pages
+git push origin gh-pages
 
 git checkout master
 

--- a/build/bin/release
+++ b/build/bin/release
@@ -34,11 +34,12 @@ cr index \
     --charts-repo https://onosproject.github.io/onos-helm-charts \
     --package-path build/release
 
-# Switch to the gh-pages branch and commit the updated index.yaml
+# Branch off the gh-pages branch and commit the updated index.yaml to a development branch
 git checkout gh-pages
+git checkout -b release-$chart
 mv build/release/index.yaml index.yaml
 git add index.yaml
 git commit -a -m "Add $chart release to index.yaml"
-git push origin gh-pages
+git push origin release-$chart
 
 git checkout $branch

--- a/build/bin/release
+++ b/build/bin/release
@@ -10,7 +10,7 @@ set -e
 
 chart=$1
 
-rm -r build/release
+rm -rf build/release
 
 owner=${GITHUB_USER:-onosproject}
 repo=${GITHUB_REPO:-onos-helm-charts}

--- a/build/bin/release
+++ b/build/bin/release
@@ -6,6 +6,7 @@ if [ "$#" -lt "1" ]; then
 fi
 
 set -x
+set -e
 
 chart=$1
 

--- a/build/bin/release
+++ b/build/bin/release
@@ -11,6 +11,9 @@ chart=$1
 
 rm -r build/release
 
+owner=${GITHUB_USER:-onosproject}
+repo=${GITHUB_REPO:-onos-helm-charts}
+remote=${GIT_REMOTE:-origin}
 branch=$(git branch --show-current)
 
 # Package the Helm chart
@@ -20,26 +23,25 @@ helm package $chart --destination build/release
 cr upload \
     --git-base-url https://api.github.com/ \
     --git-upload-url https://uploads.github.com/ \
-    --owner onosproject \
-    --git-repo onos-helm-charts \
+    --owner $owner \
+    --git-repo $repo \
     --package-path build/release
+
+# Switch to the gh-pages branch
+git checkout gh-pages
 
 # Update the repository index
 cr index \
-    --index-path build/release/index.yaml \
+    --index-path index.yaml \
     --git-base-url https://api.github.com/ \
     --git-upload-url https://uploads.github.com/ \
-    --owner onosproject \
-    --git-repo onos-helm-charts \
-    --charts-repo https://onosproject.github.io/onos-helm-charts \
+    --owner $owner \
+    --git-repo $repo \
+    --charts-repo https://$owner.github.io/$repo \
     --package-path build/release
 
-# Branch off the gh-pages branch and commit the updated index.yaml to a development branch
-git checkout gh-pages
-git checkout -b release-$chart
-mv build/release/index.yaml index.yaml
-git add index.yaml
+# Commit the updated index.yaml
 git commit -a -m "Add $chart release to index.yaml"
-git push origin release-$chart
+git push $remote gh-pages
 
 git checkout $branch

--- a/onos-topo/Chart.yaml
+++ b/onos-topo/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-topo
 description: ONOS Topology service
 kubeVersion: ">=1.12.0"
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: 1.0
 keywords:
   - onos

--- a/onos-topo/Chart.yaml
+++ b/onos-topo/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-topo
 description: ONOS Topology service
 kubeVersion: ">=1.12.0"
 type: application
-version: 0.0.2
+version: 0.0.1
 appVersion: 1.0
 keywords:
   - onos


### PR DESCRIPTION
This PR adds a script to release Helm charts to GitHub pages. This branch is a work in progress. This variation of the script is untested. In order to use it, we'd need to enable GitHub Pages for this repository.

The script takes a single argument: the name of the chart to release, e.g.:
```bash
./build/bin/release onos-ric
```