### PR TITLE
Update Helm charts to use Atomix v1beta3 API

### DIFF
--- a/onos-config/templates/consensus.yaml
+++ b/onos-config/templates/consensus.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.store.consensus.enabled }}
 {{- $name := ternary .Values.store.consensus.database (printf "%s-consensus" (include "onos-config.fullname" .)) (not (eq .Values.store.consensus.database "")) }}
-apiVersion: cloud.atomix.io/v1beta2
+apiVersion: cloud.atomix.io/v1beta3
 kind: Database
 metadata:
   name: {{ $name }}
@@ -10,15 +10,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  clusters: {{ .Values.store.consensus.clusters }}
-  template:
-    spec:
-      partitions: {{ .Values.store.consensus.partitions }}
-      storage:
-        group: storage.cloud.atomix.io
-        version: v1beta1
-        kind: RaftStorageClass
-        name: {{ $name }}
+  partitions: {{ .Values.store.consensus.partitions }}
+  storageClass:
+    group: storage.cloud.atomix.io
+    version: v1beta1
+    kind: RaftStorageClass
+    name: {{ $name }}
 ---
 apiVersion: storage.cloud.atomix.io/v1beta1
 kind: RaftStorageClass
@@ -33,4 +30,5 @@ spec:
   image: {{ .Values.store.consensus.image }}
   imagePullPolicy: {{ .Values.store.consensus.imagePullPolicy }}
   replicas: {{ .Values.store.consensus.replicas }}
+  partitionsPerCluster: {{ .Values.store.consensus.partitionsPerCluster }}
   {{- end }}

--- a/onos-config/tests/onos-config.go
+++ b/onos-config/tests/onos-config.go
@@ -29,22 +29,22 @@ type ONOSConfigSuite struct {
 // TestInstall tests installing the onos-config chart
 func (s *ONOSConfigSuite) TestInstall(t *testing.T) {
 	atomix := helm.Chart("kubernetes-controller", "https://charts.atomix.io").
-		Release("atomix-controller").
+		Release("onos-config-atomix").
 		Set("scope", "Namespace")
 	assert.NoError(t, atomix.Install(true))
 
 	raft := helm.Chart("raft-storage-controller", "https://charts.atomix.io").
-		Release("raft-storage-controller").
+		Release("onos-config-raft").
 		Set("scope", "Namespace")
 	assert.NoError(t, raft.Install(true))
 
 	topo := helm.Chart("onos-topo").
 		Release("onos-topo").
-		Set("store.controller", "atomix-controller:5679")
+		Set("store.controller", "onos-config-atomix-kubernetes-controller:5679")
 	assert.NoError(t, topo.Install(false))
 
 	config := helm.Chart("onos-config").
 		Release("onos-config").
-		Set("store.controller", "atomix-controller:5679")
+		Set("store.controller", "onos-config-atomix-kubernetes-controller:5679")
 	assert.NoError(t, config.Install(true))
 }

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -41,8 +41,8 @@ store:
     image: atomix/raft-storage-node:v0.1.0
     imagePullPolicy: IfNotPresent
     partitions: 1
-    clusters: 1
     replicas: 1
+    partitionsPerCluster: 1
 
 ingress:
   enabled: false

--- a/onos-ric/templates/cache.yaml
+++ b/onos-ric/templates/cache.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.store.cache.enabled }}
 {{- $name := ternary .Values.store.cache.database (printf "%s-cache" (include "onos-ric.fullname" .)) (not (eq .Values.store.cache.database "")) }}
-apiVersion: cloud.atomix.io/v1beta2
+apiVersion: cloud.atomix.io/v1beta3
 kind: Database
 metadata:
   name: {{ $name }}
@@ -10,15 +10,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  clusters: {{ .Values.store.cache.clusters }}
-  template:
-    spec:
-      partitions: {{ .Values.store.cache.partitions }}
-      storage:
-        group: storage.cloud.atomix.io
-        version: v1beta1
-        kind: CacheStorageClass
-        name: {{ $name }}
+  partitions: {{ .Values.store.cache.partitions }}
+  storageClass:
+    group: storage.cloud.atomix.io
+    version: v1beta1
+    kind: CacheStorageClass
+    name: {{ $name }}
 ---
 apiVersion: storage.cloud.atomix.io/v1beta1
 kind: CacheStorageClass

--- a/onos-ric/templates/consensus.yaml
+++ b/onos-ric/templates/consensus.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.store.consensus.enabled }}
 {{- $name := ternary .Values.store.consensus.database (printf "%s-consensus" (include "onos-ric.fullname" .)) (not (eq .Values.store.consensus.database "")) }}
-apiVersion: cloud.atomix.io/v1beta2
+apiVersion: cloud.atomix.io/v1beta3
 kind: Database
 metadata:
   name: {{ $name }}
@@ -10,15 +10,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  clusters: {{ .Values.store.consensus.clusters }}
-  template:
-    spec:
-      partitions: {{ .Values.store.consensus.partitions }}
-      storage:
-        group: storage.cloud.atomix.io
-        version: v1beta1
-        kind: RaftStorageClass
-        name: {{ $name }}
+  partitions: {{ .Values.store.consensus.partitions }}
+  storageClass:
+    group: storage.cloud.atomix.io
+    version: v1beta1
+    kind: RaftStorageClass
+    name: {{ $name }}
 ---
 apiVersion: storage.cloud.atomix.io/v1beta1
 kind: RaftStorageClass
@@ -33,4 +30,5 @@ spec:
   image: {{ .Values.store.consensus.image }}
   imagePullPolicy: {{ .Values.store.consensus.imagePullPolicy }}
   replicas: {{ .Values.store.consensus.replicas }}
+  partitionsPerCluster: {{ .Values.store.consensus.partitionsPerCluster }}
 {{- end }}

--- a/onos-ric/templates/deployment.yaml
+++ b/onos-ric/templates/deployment.yaml
@@ -29,31 +29,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: ric-depcheck
-          image: {{ .Values.image.depCheck | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
-            runAsUser: 0
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: PATH
-              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/
-            - name: COMMAND
-              value: "echo done"
-            - name: DEPENDENCY_POD_JSON
-              value: '[{"labels": {"name": "atomix-controller"}, "requireSameNode": false}, {"labels": {"name": "onos-topo"}, "requireSameNode": false}]'
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/onos-ric/tests/onos-ric.go
+++ b/onos-ric/tests/onos-ric.go
@@ -29,27 +29,27 @@ type ONOSRICSuite struct {
 // TestInstall tests installing the onos-ric chart
 func (s *ONOSRICSuite) TestInstall(t *testing.T) {
 	atomix := helm.Chart("kubernetes-controller", "https://charts.atomix.io").
-		Release("atomix-controller").
+		Release("onos-ric-atomix").
 		Set("scope", "Namespace")
 	assert.NoError(t, atomix.Install(true))
 
 	raft := helm.Chart("raft-storage-controller", "https://charts.atomix.io").
-		Release("raft-storage-controller").
+		Release("onos-ric-raft").
 		Set("scope", "Namespace")
 	assert.NoError(t, raft.Install(true))
 
 	cache := helm.Chart("cache-storage-controller", "https://charts.atomix.io").
-		Release("cache-storage-controller").
+		Release("onos-ric-cache").
 		Set("scope", "Namespace")
 	assert.NoError(t, cache.Install(true))
 
 	topo := helm.Chart("onos-topo").
 		Release("onos-topo").
-		Set("store.controller", "atomix-controller:5679")
+		Set("store.controller", "onos-ric-atomix-kubernetes-controller:5679")
 	assert.NoError(t, topo.Install(false))
 
 	ric := helm.Chart("onos-ric").
 		Release("onos-ric").
-		Set("store.controller", "atomix-controller:5679")
+		Set("store.controller", "onos-ric-atomix-kubernetes-controller:5679")
 	assert.NoError(t, ric.Install(true))
 }

--- a/onos-ric/values.yaml
+++ b/onos-ric/values.yaml
@@ -34,8 +34,8 @@ store:
     image: atomix/raft-storage-node:v0.1.0
     imagePullPolicy: IfNotPresent
     partitions: 1
-    clusters: 1
     replicas: 1
+    partitionsPerCluster: 1
 
 service:
   type: ClusterIP

--- a/onos-topo/templates/consensus.yaml
+++ b/onos-topo/templates/consensus.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.store.consensus.enabled }}
 {{- $name := ternary .Values.store.consensus.database (printf "%s-consensus" (include "onos-topo.fullname" .)) (not (eq .Values.store.consensus.database "")) }}
-apiVersion: cloud.atomix.io/v1beta2
+apiVersion: cloud.atomix.io/v1beta3
 kind: Database
 metadata:
   name: {{ $name }}
@@ -10,15 +10,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  clusters: {{ .Values.store.consensus.clusters }}
-  template:
-    spec:
-      partitions: {{ .Values.store.consensus.partitions }}
-      storage:
-        group: storage.cloud.atomix.io
-        version: v1beta1
-        kind: RaftStorageClass
-        name: {{ $name }}
+  partitions: {{ .Values.store.consensus.partitions }}
+  storageClass:
+    group: storage.cloud.atomix.io
+    version: v1beta1
+    kind: RaftStorageClass
+    name: {{ $name }}
 ---
 apiVersion: storage.cloud.atomix.io/v1beta1
 kind: RaftStorageClass
@@ -33,4 +30,5 @@ spec:
   image: {{ .Values.store.consensus.image }}
   imagePullPolicy: {{ .Values.store.consensus.imagePullPolicy }}
   replicas: {{ .Values.store.consensus.replicas }}
+  partitionsPerCluster: {{ .Values.store.consensus.partitionsPerCluster }}
 {{- end }}

--- a/onos-topo/tests/onos-topo.go
+++ b/onos-topo/tests/onos-topo.go
@@ -29,17 +29,17 @@ type ONOSTopoSuite struct {
 // TestInstall tests installing the onos-topo chart
 func (s *ONOSTopoSuite) TestInstall(t *testing.T) {
 	atomix := helm.Chart("kubernetes-controller", "https://charts.atomix.io").
-		Release("atomix-controller").
+		Release("onos-topo-atomix").
 		Set("scope", "Namespace")
 	assert.NoError(t, atomix.Install(true))
 
 	raft := helm.Chart("raft-storage-controller", "https://charts.atomix.io").
-		Release("raft-storage-controller").
+		Release("onos-topo-raft").
 		Set("scope", "Namespace")
 	assert.NoError(t, raft.Install(true))
 
 	topo := helm.Chart("onos-topo").
 		Release("onos-topo").
-		Set("store.controller", "atomix-controller:5679")
+		Set("store.controller", "onos-topo-atomix-kubernetes-controller:5679")
 	assert.NoError(t, topo.Install(true))
 }

--- a/onos-topo/values.yaml
+++ b/onos-topo/values.yaml
@@ -24,8 +24,8 @@ store:
     image: atomix/raft-storage-node:v0.1.0
     imagePullPolicy: IfNotPresent
     partitions: 1
-    clusters: 1
     replicas: 1
+    partitionsPerCluster: 1
 
 ingress:
   enabled: false

--- a/sd-ran/requirements.yaml
+++ b/sd-ran/requirements.yaml
@@ -6,15 +6,15 @@ dependencies:
 - name: kubernetes-controller
   condition: import.atomix-controller.enabled
   repository: https://charts.atomix.io
-  version: 0.3.4
+  version: 0.4.1
 - name: raft-storage-controller
   condition: import.atomix-raft-storage-controller.enabled
   repository: https://charts.atomix.io
-  version: 0.2.3
+  version: 0.3.1
 - name: cache-storage-controller
   condition: import.atomix-cache-storage-controller.enabled
   repository: https://charts.atomix.io
-  version: 0.2.3
+  version: 0.3.1
 - name: onos-ric
   condition: import.onos-ric.enabled
   repository: file://../onos-ric

--- a/sd-ran/values.yaml
+++ b/sd-ran/values.yaml
@@ -4,11 +4,11 @@
 
 import:
   atomix-controller:
-    enabled: true
+    enabled: false
   atomix-raft-storage-controller:
-    enabled: true
+    enabled: false
   atomix-cache-storage-controller:
-    enabled: true
+    enabled: false
   nem-monitoring:
     enabled: true
   onos-ric:


### PR DESCRIPTION
This PR updates Atomix resources to use the v1beta3 API. The latest version of the Atomix API and Helm charts fix a few issues we've had with naming and deployment order.