### PR TITLE
Ran-sim added a option to specify the towers config

### DIFF
--- a/ran-simulator/templates/deployment.yaml
+++ b/ran-simulator/templates/deployment.yaml
@@ -46,9 +46,6 @@ spec:
             - "-fade={{ .Values.fade }}"
             - "-googleAPIKey={{ .Values.googleApiKey }}"
             - "-locationsScale={{ .Values.locationsScale }}"
-            - "-mapCenterLat={{ .Values.mapCenterLat }}"
-            - "-mapCenterLng={{ .Values.mapCenterLng }}"
-            - "-maxUEsPerTower={{ .Values.maxUEsPerTower }}"
             - "-maxUEs={{ .Values.maxUEs }}"
             - "-metricsAllHoEvents={{ .Values.metricsAllHoEvents }}"
             - "-metricsPort={{ .Values.metricsPort }}"
@@ -56,12 +53,8 @@ spec:
             - "-showPower={{ .Values.showPower }}"
             - "-showRoutes={{ .Values.showRoutes }}"
             - "-stepDelayMs={{ .Values.stepDelayMs }}"
-            - "-towerCols={{ .Values.towerCols }}"
-            - "-towerRows={{ .Values.towerRows }}"
-            - "-towerSpacingHoriz={{ .Values.towerSpacingHoriz }}"
-            - "-towerSpacingVert={{ .Values.towerSpacingVert }}"
             - "-zoom={{ .Values.zoom }}"
-            - "-loglevel={{ .Values.loglevel }}"
+            - "-towerConfigName={{ .Values.towerConfigName }}"
           ports:
             - name: grpc
               containerPort: 5150

--- a/ran-simulator/values.yaml
+++ b/ran-simulator/values.yaml
@@ -6,16 +6,13 @@ replicaCount: 1
 
 image:
   repository: onosproject/ran-simulator
-  tag: v0.6.0
+  tag: latest
   pullPolicy: IfNotPresent
   pullSecrets: []
 
 fade: true
 googleApiKey: "YOUR_API_KEY_HERE"
 locationsScale: 1.25
-mapCenterLat: 52.52
-mapCenterLng: 13.405
-maxUEsPerTower: 5
 maxUEs: 300
 metricsAllHoEvents: false
 metricsPort: 9090
@@ -23,12 +20,8 @@ minUEs: 3
 showPower: true
 showRoutes: true
 stepDelayMs: 1000
-towerCols: 3
-towerRows: 3
-towerSpacingHoriz: 0.033
-towerSpacingVert: 0.02
 zoom: 13
-loglevel: warn
+towerConfigName: berlin-honeycomb-4-3.yaml
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Try it out with
```
helm -n micro-onos install ran-simulator ran-simulator --set image.tag=latest --set towerConfigName=berlin-honeycomb-169-6.yaml --set locationsScale=0.7
```