### PR TITLE
sd-ran: post install job populates onos-topo and onos-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ publish: # @HELP publish version on github
 bumponosdeps: # @HELP update "onosproject" go dependencies and push patch to git.
 	./../build-tools/bump-onos-deps ${VERSION}
 
+clean: # @HELP clean up temporary files.
+	rm -rf sd-ran/charts sd-ran/Chart.lock
+
 help:
 	@grep -E '^.*: *# *@HELP' $(MAKEFILE_LIST) \
     | sort \

--- a/onos-cli/Chart.yaml
+++ b/onos-cli/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-cli
 description: ONOS Command Line Interface
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: v0.6.5
 keywords:
   - onos

--- a/ran-simulator/templates/deployment.yaml
+++ b/ran-simulator/templates/deployment.yaml
@@ -54,7 +54,6 @@ spec:
             - "-showRoutes={{ .Values.showRoutes }}"
             - "-stepDelayMs={{ .Values.stepDelayMs }}"
             - "-zoom={{ .Values.zoom }}"
-            - "-towerConfigName={{ .Values.towerConfigName }}"
           ports:
             - name: grpc
               containerPort: 5150

--- a/ran-simulator/values.yaml
+++ b/ran-simulator/values.yaml
@@ -21,7 +21,6 @@ showPower: true
 showRoutes: true
 stepDelayMs: 1000
 zoom: 13
-towerConfigName: berlin-honeycomb-4-3.yaml
 
 imagePullSecrets: []
 nameOverride: ""

--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -3,7 +3,7 @@ name: sd-ran
 description: Umbrella chart to deploy all ONOS-RIC and simulator
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.8
+version: 0.0.9
 appVersion: v0.6.5
 keywords:
   - onos
@@ -63,4 +63,4 @@ dependencies:
   - name: onos-cli
     condition: import.onos-cli.enabled
     repository: https://charts.onosproject.org
-    version: 0.0.2
+    version: 0.0.3

--- a/sd-ran/files/configs/README.md
+++ b/sd-ran/files/configs/README.md
@@ -1,0 +1,9 @@
+# Config files
+
+Copied here from ran-simulator/pkg/config
+
+Available in /home/onos at runtime. Needed
+to populate onos-topo and onos-config through
+a post-install action on startup of sd-ran. 
+
+> TODO: automate the process of copying these

--- a/sd-ran/files/configs/berlin-honeycomb-331-3-A-gnmi.yaml
+++ b/sd-ran/files/configs/berlin-honeycomb-331-3-A-gnmi.yaml
@@ -1,0 +1,5308 @@
+setrequest:
+  prefix:
+    elem:
+    - name: e2node
+  delete: []
+  replace: []
+  update:
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001420
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001420
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001421
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001421
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001422
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001422
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001423
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001423
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001424
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001424
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001425
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001425
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001426
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001426
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001427
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001427
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001428
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001428
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001429
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001429
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001430
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001430
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001431
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001431
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001432
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001432
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001433
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001433
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001434
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001434
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001435
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001435
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001436
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001436
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001437
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001437
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001438
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001438
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001439
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001439
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000143a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000143a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000143b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000143b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000143c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000143c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000143d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000143d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000143e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000143e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000143f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000143f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001440
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001440
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001441
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001441
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001442
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001442
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001443
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001443
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001444
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001444
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001445
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001445
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001446
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001446
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001447
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001447
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001448
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001448
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001449
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001449
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000144a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000144a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000144b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000144b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000144c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000144c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000144d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000144d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000144e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000144e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000144f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000144f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001450
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001450
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001451
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001451
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001452
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001452
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001453
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001453
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001454
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001454
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001455
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001455
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001456
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001456
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001457
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001457
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001458
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001458
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001459
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001459
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000145a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000145a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000145b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000145b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000145c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000145c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000145d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000145d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000145e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000145e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000145f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000145f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001460
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001460
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001461
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001461
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001462
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001462
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001463
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001463
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001464
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001464
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001465
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001465
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001466
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001466
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001467
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001467
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001468
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001468
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001469
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001469
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000146a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000146a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000146b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000146b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000146c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000146c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000146d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000146d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000146e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000146e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000146f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000146f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001470
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001470
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001471
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001471
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001472
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001472
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001473
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001473
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001474
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001474
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001475
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001475
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001476
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001476
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001477
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001477
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001478
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001478
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001479
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001479
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000147a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000147a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000147b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000147b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000147c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000147c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000147d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000147d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000147e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000147e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000147f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000147f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001480
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001480
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001481
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001481
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001482
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001482
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001483
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001483
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001484
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001484
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001485
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001485
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001486
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001486
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001487
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001487
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001488
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001488
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001489
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001489
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000148a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000148a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000148b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000148b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000148c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000148c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000148d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000148d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000148e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000148e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000148f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000148f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001490
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001490
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001491
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001491
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001492
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001492
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001493
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001493
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001494
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001494
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001495
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001495
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001496
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001496
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001497
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001497
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001498
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001498
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001499
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001499
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000149a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000149a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000149b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000149b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000149c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000149c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000149d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000149d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000149e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000149e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000149f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000149f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014a9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014a9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014aa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014aa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ab
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ab
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ac
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ac
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ad
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ad
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ae
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ae
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014af
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014af
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014b9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014b9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ba
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ba
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014bb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014bb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014bc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014bc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014bd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014bd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014be
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014be
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014bf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014bf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014c9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014c9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ca
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ca
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014cb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014cb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014cc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014cc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014cd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014cd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ce
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ce
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014cf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014cf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014d9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014d9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014da
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014da
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014db
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014db
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014dc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014dc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014dd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014dd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014de
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014de
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014df
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014df
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014e9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014e9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ea
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ea
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014eb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014eb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ec
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ec
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ed
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ed
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ee
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ee
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ef
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ef
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014f9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014f9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014fa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014fa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014fb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014fb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014fc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014fc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014fd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014fd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014fe
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014fe
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00014ff
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00014ff
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001500
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001500
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001501
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001501
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001502
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001502
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001503
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001503
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001504
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001504
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001505
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001505
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001506
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001506
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001507
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001507
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001508
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001508
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001509
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001509
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000150a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000150a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000150b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000150b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000150c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000150c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000150d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000150d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000150e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000150e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000150f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000150f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001510
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001510
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001511
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001511
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001512
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001512
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001513
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001513
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001514
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001514
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001515
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001515
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001516
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001516
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001517
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001517
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001518
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001518
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001519
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001519
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000151a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000151a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000151b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000151b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000151c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000151c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000151d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000151d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000151e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000151e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000151f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000151f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001520
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001520
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001521
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001521
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001522
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001522
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001523
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001523
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001524
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001524
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001525
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001525
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001526
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001526
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001527
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001527
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001528
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001528
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001529
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001529
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000152a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000152a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000152b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000152b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000152c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000152c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000152d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000152d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000152e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000152e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000152f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000152f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001530
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001530
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001531
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001531
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001532
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001532
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001533
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001533
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001534
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001534
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001535
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001535
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001536
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001536
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001537
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001537
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001538
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001538
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001539
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001539
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000153a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000153a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000153b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000153b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000153c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000153c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000153d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000153d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000153e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000153e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000153f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000153f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001540
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001540
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001541
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001541
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001542
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001542
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001543
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001543
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001544
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001544
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001545
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001545
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001546
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001546
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001547
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001547
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001548
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001548
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001549
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001549
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000154a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000154a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000154b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000154b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000154c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000154c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000154d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000154d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000154e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000154e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000154f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000154f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001550
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001550
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001551
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001551
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001552
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001552
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001553
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001553
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001554
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001554
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001555
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001555
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001556
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001556
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001557
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001557
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001558
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001558
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001559
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001559
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000155a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000155a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000155b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000155b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000155c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000155c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000155d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000155d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000155e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000155e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000155f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000155f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001560
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001560
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001561
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001561
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001562
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001562
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001563
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001563
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001564
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001564
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001565
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001565
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001566
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001566
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001567
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001567
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001568
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001568
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001569
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001569
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000156a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000156a
+    val:
+      uintvalue:
+        uintval: 21
+  extension:
+    - id: 101
+      value: 1.0.0
+    - id: 102
+      value: E2Node

--- a/sd-ran/files/configs/berlin-honeycomb-331-3-B-gnmi.yaml
+++ b/sd-ran/files/configs/berlin-honeycomb-331-3-B-gnmi.yaml
@@ -1,0 +1,5308 @@
+setrequest:
+  prefix:
+    elem:
+    - name: e2node
+  delete: []
+  replace: []
+  update:
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000156b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000156b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000156c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000156c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000156d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000156d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000156e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000156e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000156f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000156f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001570
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001570
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001571
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001571
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001572
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001572
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001573
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001573
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001574
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001574
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001575
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001575
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001576
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001576
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001577
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001577
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001578
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001578
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001579
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001579
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000157a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000157a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000157b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000157b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000157c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000157c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000157d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000157d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000157e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000157e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000157f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000157f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001580
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001580
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001581
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001581
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001582
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001582
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001583
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001583
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001584
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001584
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001585
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001585
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001586
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001586
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001587
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001587
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001588
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001588
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001589
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001589
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000158a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000158a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000158b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000158b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000158c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000158c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000158d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000158d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000158e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000158e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000158f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000158f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001590
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001590
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001591
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001591
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001592
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001592
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001593
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001593
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001594
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001594
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001595
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001595
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001596
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001596
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001597
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001597
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001598
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001598
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001599
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001599
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000159a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000159a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000159b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000159b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000159c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000159c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000159d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000159d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000159e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000159e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000159f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000159f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015a9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015a9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015aa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015aa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ab
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ab
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ac
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ac
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ad
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ad
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ae
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ae
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015af
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015af
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015b9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015b9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ba
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ba
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015bb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015bb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015bc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015bc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015bd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015bd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015be
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015be
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015bf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015bf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015c9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015c9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ca
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ca
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015cb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015cb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015cc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015cc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015cd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015cd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ce
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ce
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015cf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015cf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015d9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015d9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015da
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015da
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015db
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015db
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015dc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015dc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015dd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015dd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015de
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015de
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015df
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015df
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015e9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015e9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ea
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ea
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015eb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015eb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ec
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ec
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ed
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ed
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ee
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ee
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ef
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ef
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015f9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015f9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015fa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015fa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015fb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015fb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015fc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015fc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015fd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015fd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015fe
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015fe
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00015ff
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00015ff
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001600
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001600
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001601
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001601
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001602
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001602
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001603
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001603
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001604
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001604
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001605
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001605
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001606
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001606
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001607
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001607
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001608
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001608
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001609
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001609
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000160a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000160a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000160b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000160b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000160c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000160c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000160d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000160d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000160e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000160e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000160f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000160f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001610
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001610
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001611
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001611
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001612
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001612
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001613
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001613
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001614
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001614
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001615
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001615
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001616
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001616
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001617
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001617
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001618
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001618
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001619
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001619
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000161a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000161a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000161b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000161b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000161c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000161c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000161d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000161d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000161e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000161e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000161f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000161f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001620
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001620
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001621
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001621
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001622
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001622
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001623
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001623
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001624
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001624
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001625
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001625
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001626
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001626
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001627
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001627
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001628
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001628
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001629
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001629
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000162a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000162a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000162b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000162b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000162c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000162c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000162d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000162d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000162e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000162e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000162f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000162f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001630
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001630
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001631
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001631
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001632
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001632
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001633
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001633
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001634
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001634
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001635
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001635
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001636
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001636
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001637
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001637
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001638
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001638
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001639
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001639
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000163a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000163a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000163b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000163b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000163c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000163c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000163d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000163d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000163e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000163e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000163f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000163f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001640
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001640
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001641
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001641
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001642
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001642
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001643
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001643
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001644
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001644
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001645
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001645
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001646
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001646
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001647
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001647
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001648
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001648
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001649
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001649
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000164a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000164a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000164b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000164b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000164c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000164c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000164d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000164d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000164e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000164e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000164f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000164f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001650
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001650
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001651
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001651
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001652
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001652
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001653
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001653
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001654
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001654
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001655
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001655
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001656
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001656
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001657
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001657
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001658
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001658
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001659
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001659
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000165a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000165a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000165b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000165b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000165c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000165c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000165d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000165d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000165e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000165e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000165f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000165f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001660
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001660
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001661
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001661
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001662
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001662
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001663
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001663
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001664
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001664
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001665
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001665
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001666
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001666
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001667
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001667
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001668
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001668
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001669
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001669
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000166a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000166a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000166b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000166b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000166c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000166c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000166d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000166d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000166e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000166e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000166f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000166f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001670
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001670
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001671
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001671
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001672
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001672
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001673
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001673
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001674
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001674
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001675
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001675
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001676
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001676
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001677
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001677
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001678
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001678
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001679
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001679
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000167a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000167a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000167b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000167b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000167c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000167c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000167d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000167d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000167e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000167e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000167f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000167f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001680
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001680
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001681
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001681
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001682
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001682
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001683
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001683
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001684
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001684
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001685
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001685
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001686
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001686
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001687
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001687
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001688
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001688
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001689
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001689
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000168a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000168a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000168b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000168b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000168c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000168c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000168d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000168d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000168e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000168e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000168f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000168f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001690
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001690
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001691
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001691
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001692
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001692
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001693
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001693
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001694
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001694
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001695
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001695
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001696
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001696
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001697
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001697
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001698
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001698
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001699
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001699
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000169a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000169a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000169b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000169b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000169c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000169c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000169d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000169d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000169e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000169e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000169f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000169f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016a9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016a9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016aa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016aa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ab
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ab
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ac
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ac
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ad
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ad
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ae
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ae
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016af
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016af
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b5
+    val:
+      uintvalue:
+        uintval: 21
+  extension:
+    - id: 101
+      value: 1.0.0
+    - id: 102
+      value: E2Node

--- a/sd-ran/files/configs/berlin-honeycomb-331-3-C-gnmi.yaml
+++ b/sd-ran/files/configs/berlin-honeycomb-331-3-C-gnmi.yaml
@@ -1,0 +1,5308 @@
+setrequest:
+  prefix:
+    elem:
+    - name: e2node
+  delete: []
+  replace: []
+  update:
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016b9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016b9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ba
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ba
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016bb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016bb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016bc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016bc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016bd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016bd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016be
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016be
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016bf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016bf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016c9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016c9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ca
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ca
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016cb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016cb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016cc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016cc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016cd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016cd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ce
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ce
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016cf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016cf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016d9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016d9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016da
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016da
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016db
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016db
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016dc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016dc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016dd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016dd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016de
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016de
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016df
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016df
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016e9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016e9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ea
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ea
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016eb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016eb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ec
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ec
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ed
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ed
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ee
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ee
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ef
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ef
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016f9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016f9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016fa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016fa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016fb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016fb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016fc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016fc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016fd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016fd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016fe
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016fe
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00016ff
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00016ff
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001700
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001700
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001701
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001701
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001702
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001702
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001703
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001703
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001704
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001704
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001705
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001705
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001706
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001706
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001707
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001707
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001708
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001708
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001709
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001709
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000170a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000170a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000170b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000170b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000170c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000170c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000170d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000170d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000170e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000170e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000170f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000170f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001710
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001710
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001711
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001711
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001712
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001712
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001713
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001713
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001714
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001714
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001715
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001715
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001716
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001716
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001717
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001717
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001718
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001718
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001719
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001719
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000171a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000171a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000171b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000171b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000171c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000171c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000171d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000171d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000171e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000171e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000171f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000171f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001720
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001720
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001721
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001721
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001722
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001722
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001723
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001723
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001724
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001724
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001725
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001725
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001726
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001726
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001727
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001727
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001728
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001728
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001729
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001729
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000172a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000172a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000172b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000172b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000172c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000172c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000172d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000172d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000172e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000172e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000172f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000172f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001730
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001730
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001731
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001731
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001732
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001732
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001733
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001733
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001734
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001734
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001735
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001735
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001736
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001736
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001737
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001737
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001738
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001738
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001739
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001739
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000173a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000173a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000173b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000173b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000173c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000173c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000173d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000173d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000173e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000173e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000173f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000173f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001740
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001740
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001741
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001741
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001742
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001742
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001743
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001743
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001744
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001744
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001745
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001745
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001746
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001746
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001747
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001747
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001748
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001748
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001749
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001749
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000174a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000174a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000174b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000174b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000174c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000174c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000174d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000174d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000174e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000174e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000174f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000174f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001750
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001750
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001751
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001751
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001752
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001752
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001753
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001753
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001754
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001754
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001755
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001755
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001756
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001756
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001757
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001757
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001758
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001758
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001759
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001759
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000175a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000175a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000175b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000175b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000175c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000175c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000175d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000175d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000175e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000175e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000175f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000175f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001760
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001760
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001761
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001761
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001762
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001762
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001763
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001763
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001764
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001764
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001765
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001765
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001766
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001766
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001767
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001767
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001768
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001768
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001769
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001769
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000176a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000176a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000176b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000176b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000176c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000176c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000176d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000176d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000176e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000176e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000176f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000176f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001770
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001770
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001771
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001771
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001772
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001772
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001773
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001773
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001774
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001774
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001775
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001775
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001776
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001776
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001777
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001777
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001778
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001778
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001779
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001779
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000177a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000177a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000177b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000177b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000177c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000177c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000177d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000177d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000177e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000177e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000177f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000177f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001780
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001780
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001781
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001781
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001782
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001782
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001783
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001783
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001784
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001784
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001785
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001785
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001786
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001786
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001787
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001787
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001788
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001788
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001789
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001789
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000178a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000178a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000178b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000178b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000178c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000178c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000178d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000178d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000178e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000178e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000178f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000178f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001790
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001790
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001791
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001791
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001792
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001792
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001793
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001793
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001794
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001794
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001795
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001795
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001796
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001796
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001797
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001797
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001798
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001798
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001799
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001799
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000179a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000179a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000179b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000179b
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000179c
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000179c
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000179d
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000179d
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000179e
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000179e
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000179f
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000179f
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017a9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017a9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017aa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017aa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ab
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ab
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ac
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ac
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ad
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ad
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ae
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ae
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017af
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017af
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017b9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017b9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ba
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ba
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017bb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017bb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017bc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017bc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017bd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017bd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017be
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017be
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017bf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017bf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017c9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017c9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ca
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ca
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017cb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017cb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017cc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017cc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017cd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017cd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ce
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ce
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017cf
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017cf
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017d9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017d9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017da
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017da
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017db
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017db
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017dc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017dc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017dd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017dd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017de
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017de
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017df
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017df
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017e9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017e9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ea
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ea
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017eb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017eb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ec
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ec
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ed
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ed
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ee
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ee
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ef
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ef
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f0
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f0
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f1
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f1
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f2
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f2
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f3
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f3
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f4
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f4
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f5
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f5
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f6
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f6
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f7
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f7
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f8
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f8
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017f9
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017f9
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017fa
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017fa
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017fb
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017fb
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017fc
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017fc
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017fd
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017fd
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017fe
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017fe
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-00017ff
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-00017ff
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001800
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001800
+    val:
+      uintvalue:
+        uintval: 21
+  extension:
+    - id: 101
+      value: 1.0.0
+    - id: 102
+      value: E2Node

--- a/sd-ran/files/configs/berlin-honeycomb-331-3-topo.yaml
+++ b/sd-ran/files/configs/berlin-honeycomb-331-3-topo.yaml
@@ -1,0 +1,26812 @@
+topodevices:
+- id: 315010-0001420
+  revision: 0
+  address: ran-simulator:5152
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001420"
+    grpcport: "5152"
+    latitude: "52.000385"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 0 Cell 0
+- id: 315010-0001421
+  revision: 0
+  address: ran-simulator:5153
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001421"
+    grpcport: "5153"
+    latitude: "52.000385"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 0 Cell 1
+- id: 315010-0001422
+  revision: 0
+  address: ran-simulator:5154
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001422"
+    grpcport: "5154"
+    latitude: "52.000385"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 0 Cell 2
+- id: 315010-0001423
+  revision: 0
+  address: ran-simulator:5155
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001423"
+    grpcport: "5155"
+    latitude: "52.026366"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 1 Cell 0
+- id: 315010-0001424
+  revision: 0
+  address: ran-simulator:5156
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001424"
+    grpcport: "5156"
+    latitude: "52.026366"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 1 Cell 1
+- id: 315010-0001425
+  revision: 0
+  address: ran-simulator:5157
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001425"
+    grpcport: "5157"
+    latitude: "52.026366"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 1 Cell 2
+- id: 315010-0001426
+  revision: 0
+  address: ran-simulator:5158
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001426"
+    grpcport: "5158"
+    latitude: "52.052346"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 2 Cell 0
+- id: 315010-0001427
+  revision: 0
+  address: ran-simulator:5159
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001427"
+    grpcport: "5159"
+    latitude: "52.052346"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 2 Cell 1
+- id: 315010-0001428
+  revision: 0
+  address: ran-simulator:5160
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001428"
+    grpcport: "5160"
+    latitude: "52.052346"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 2 Cell 2
+- id: 315010-0001429
+  revision: 0
+  address: ran-simulator:5161
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001429"
+    grpcport: "5161"
+    latitude: "52.078327"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 3 Cell 0
+- id: 315010-000142a
+  revision: 0
+  address: ran-simulator:5162
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000142a
+    grpcport: "5162"
+    latitude: "52.078327"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 3 Cell 1
+- id: 315010-000142b
+  revision: 0
+  address: ran-simulator:5163
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000142b
+    grpcport: "5163"
+    latitude: "52.078327"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 3 Cell 2
+- id: 315010-000142c
+  revision: 0
+  address: ran-simulator:5164
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000142c
+    grpcport: "5164"
+    latitude: "52.104308"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 4 Cell 0
+- id: 315010-000142d
+  revision: 0
+  address: ran-simulator:5165
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000142d
+    grpcport: "5165"
+    latitude: "52.104308"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 4 Cell 1
+- id: 315010-000142e
+  revision: 0
+  address: ran-simulator:5166
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000142e
+    grpcport: "5166"
+    latitude: "52.104308"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 4 Cell 2
+- id: 315010-000142f
+  revision: 0
+  address: ran-simulator:5167
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000142f
+    grpcport: "5167"
+    latitude: "52.130289"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 5 Cell 0
+- id: 315010-0001430
+  revision: 0
+  address: ran-simulator:5168
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001430"
+    grpcport: "5168"
+    latitude: "52.130289"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 5 Cell 1
+- id: 315010-0001431
+  revision: 0
+  address: ran-simulator:5169
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001431"
+    grpcport: "5169"
+    latitude: "52.130289"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 5 Cell 2
+- id: 315010-0001432
+  revision: 0
+  address: ran-simulator:5170
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001432"
+    grpcport: "5170"
+    latitude: "52.156269"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 6 Cell 0
+- id: 315010-0001433
+  revision: 0
+  address: ran-simulator:5171
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001433"
+    grpcport: "5171"
+    latitude: "52.156269"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 6 Cell 1
+- id: 315010-0001434
+  revision: 0
+  address: ran-simulator:5172
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001434"
+    grpcport: "5172"
+    latitude: "52.156269"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 6 Cell 2
+- id: 315010-0001435
+  revision: 0
+  address: ran-simulator:5173
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001435"
+    grpcport: "5173"
+    latitude: "52.182250"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 7 Cell 0
+- id: 315010-0001436
+  revision: 0
+  address: ran-simulator:5174
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001436"
+    grpcport: "5174"
+    latitude: "52.182250"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 7 Cell 1
+- id: 315010-0001437
+  revision: 0
+  address: ran-simulator:5175
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001437"
+    grpcport: "5175"
+    latitude: "52.182250"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 7 Cell 2
+- id: 315010-0001438
+  revision: 0
+  address: ran-simulator:5176
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001438"
+    grpcport: "5176"
+    latitude: "52.208231"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 8 Cell 0
+- id: 315010-0001439
+  revision: 0
+  address: ran-simulator:5177
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001439"
+    grpcport: "5177"
+    latitude: "52.208231"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 8 Cell 1
+- id: 315010-000143a
+  revision: 0
+  address: ran-simulator:5178
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000143a
+    grpcport: "5178"
+    latitude: "52.208231"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 8 Cell 2
+- id: 315010-000143b
+  revision: 0
+  address: ran-simulator:5179
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000143b
+    grpcport: "5179"
+    latitude: "52.234212"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 9 Cell 0
+- id: 315010-000143c
+  revision: 0
+  address: ran-simulator:5180
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000143c
+    grpcport: "5180"
+    latitude: "52.234212"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 9 Cell 1
+- id: 315010-000143d
+  revision: 0
+  address: ran-simulator:5181
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000143d
+    grpcport: "5181"
+    latitude: "52.234212"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 9 Cell 2
+- id: 315010-000143e
+  revision: 0
+  address: ran-simulator:5182
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000143e
+    grpcport: "5182"
+    latitude: "52.260192"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 10 Cell 0
+- id: 315010-000143f
+  revision: 0
+  address: ran-simulator:5183
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000143f
+    grpcport: "5183"
+    latitude: "52.260192"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 10 Cell 1
+- id: 315010-0001440
+  revision: 0
+  address: ran-simulator:5184
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001440"
+    grpcport: "5184"
+    latitude: "52.260192"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 10 Cell 2
+- id: 315010-0001441
+  revision: 0
+  address: ran-simulator:5185
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001441"
+    grpcport: "5185"
+    latitude: "52.026366"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 11 Cell 0
+- id: 315010-0001442
+  revision: 0
+  address: ran-simulator:5186
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001442"
+    grpcport: "5186"
+    latitude: "52.026366"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 11 Cell 1
+- id: 315010-0001443
+  revision: 0
+  address: ran-simulator:5187
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001443"
+    grpcport: "5187"
+    latitude: "52.026366"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 11 Cell 2
+- id: 315010-0001444
+  revision: 0
+  address: ran-simulator:5188
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001444"
+    grpcport: "5188"
+    latitude: "52.052346"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 12 Cell 0
+- id: 315010-0001445
+  revision: 0
+  address: ran-simulator:5189
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001445"
+    grpcport: "5189"
+    latitude: "52.052346"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 12 Cell 1
+- id: 315010-0001446
+  revision: 0
+  address: ran-simulator:5190
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001446"
+    grpcport: "5190"
+    latitude: "52.052346"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 12 Cell 2
+- id: 315010-0001447
+  revision: 0
+  address: ran-simulator:5191
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001447"
+    grpcport: "5191"
+    latitude: "52.078327"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 13 Cell 0
+- id: 315010-0001448
+  revision: 0
+  address: ran-simulator:5192
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001448"
+    grpcport: "5192"
+    latitude: "52.078327"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 13 Cell 1
+- id: 315010-0001449
+  revision: 0
+  address: ran-simulator:5193
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001449"
+    grpcport: "5193"
+    latitude: "52.078327"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 13 Cell 2
+- id: 315010-000144a
+  revision: 0
+  address: ran-simulator:5194
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000144a
+    grpcport: "5194"
+    latitude: "52.104308"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 14 Cell 0
+- id: 315010-000144b
+  revision: 0
+  address: ran-simulator:5195
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000144b
+    grpcport: "5195"
+    latitude: "52.104308"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 14 Cell 1
+- id: 315010-000144c
+  revision: 0
+  address: ran-simulator:5196
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000144c
+    grpcport: "5196"
+    latitude: "52.104308"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 14 Cell 2
+- id: 315010-000144d
+  revision: 0
+  address: ran-simulator:5197
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000144d
+    grpcport: "5197"
+    latitude: "52.130289"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 15 Cell 0
+- id: 315010-000144e
+  revision: 0
+  address: ran-simulator:5198
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000144e
+    grpcport: "5198"
+    latitude: "52.130289"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 15 Cell 1
+- id: 315010-000144f
+  revision: 0
+  address: ran-simulator:5199
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000144f
+    grpcport: "5199"
+    latitude: "52.130289"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 15 Cell 2
+- id: 315010-0001450
+  revision: 0
+  address: ran-simulator:5200
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001450"
+    grpcport: "5200"
+    latitude: "52.156269"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 16 Cell 0
+- id: 315010-0001451
+  revision: 0
+  address: ran-simulator:5201
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001451"
+    grpcport: "5201"
+    latitude: "52.156269"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 16 Cell 1
+- id: 315010-0001452
+  revision: 0
+  address: ran-simulator:5202
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001452"
+    grpcport: "5202"
+    latitude: "52.156269"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 16 Cell 2
+- id: 315010-0001453
+  revision: 0
+  address: ran-simulator:5203
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001453"
+    grpcport: "5203"
+    latitude: "52.182250"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 17 Cell 0
+- id: 315010-0001454
+  revision: 0
+  address: ran-simulator:5204
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001454"
+    grpcport: "5204"
+    latitude: "52.182250"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 17 Cell 1
+- id: 315010-0001455
+  revision: 0
+  address: ran-simulator:5205
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001455"
+    grpcport: "5205"
+    latitude: "52.182250"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 17 Cell 2
+- id: 315010-0001456
+  revision: 0
+  address: ran-simulator:5206
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001456"
+    grpcport: "5206"
+    latitude: "52.208231"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 18 Cell 0
+- id: 315010-0001457
+  revision: 0
+  address: ran-simulator:5207
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001457"
+    grpcport: "5207"
+    latitude: "52.208231"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 18 Cell 1
+- id: 315010-0001458
+  revision: 0
+  address: ran-simulator:5208
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001458"
+    grpcport: "5208"
+    latitude: "52.208231"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 18 Cell 2
+- id: 315010-0001459
+  revision: 0
+  address: ran-simulator:5209
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001459"
+    grpcport: "5209"
+    latitude: "52.234212"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 19 Cell 0
+- id: 315010-000145a
+  revision: 0
+  address: ran-simulator:5210
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000145a
+    grpcport: "5210"
+    latitude: "52.234212"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 19 Cell 1
+- id: 315010-000145b
+  revision: 0
+  address: ran-simulator:5211
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000145b
+    grpcport: "5211"
+    latitude: "52.234212"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 19 Cell 2
+- id: 315010-000145c
+  revision: 0
+  address: ran-simulator:5212
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000145c
+    grpcport: "5212"
+    latitude: "52.260192"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 20 Cell 0
+- id: 315010-000145d
+  revision: 0
+  address: ran-simulator:5213
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000145d
+    grpcport: "5213"
+    latitude: "52.260192"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 20 Cell 1
+- id: 315010-000145e
+  revision: 0
+  address: ran-simulator:5214
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000145e
+    grpcport: "5214"
+    latitude: "52.260192"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 20 Cell 2
+- id: 315010-000145f
+  revision: 0
+  address: ran-simulator:5215
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000145f
+    grpcport: "5215"
+    latitude: "52.286173"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 21 Cell 0
+- id: 315010-0001460
+  revision: 0
+  address: ran-simulator:5216
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001460"
+    grpcport: "5216"
+    latitude: "52.286173"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 21 Cell 1
+- id: 315010-0001461
+  revision: 0
+  address: ran-simulator:5217
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001461"
+    grpcport: "5217"
+    latitude: "52.286173"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 21 Cell 2
+- id: 315010-0001462
+  revision: 0
+  address: ran-simulator:5218
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001462"
+    grpcport: "5218"
+    latitude: "52.312154"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 22 Cell 0
+- id: 315010-0001463
+  revision: 0
+  address: ran-simulator:5219
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001463"
+    grpcport: "5219"
+    latitude: "52.312154"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 22 Cell 1
+- id: 315010-0001464
+  revision: 0
+  address: ran-simulator:5220
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001464"
+    grpcport: "5220"
+    latitude: "52.312154"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 22 Cell 2
+- id: 315010-0001465
+  revision: 0
+  address: ran-simulator:5221
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001465"
+    grpcport: "5221"
+    latitude: "52.052346"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 23 Cell 0
+- id: 315010-0001466
+  revision: 0
+  address: ran-simulator:5222
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001466"
+    grpcport: "5222"
+    latitude: "52.052346"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 23 Cell 1
+- id: 315010-0001467
+  revision: 0
+  address: ran-simulator:5223
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001467"
+    grpcport: "5223"
+    latitude: "52.052346"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 23 Cell 2
+- id: 315010-0001468
+  revision: 0
+  address: ran-simulator:5224
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001468"
+    grpcport: "5224"
+    latitude: "52.078327"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 24 Cell 0
+- id: 315010-0001469
+  revision: 0
+  address: ran-simulator:5225
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001469"
+    grpcport: "5225"
+    latitude: "52.078327"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 24 Cell 1
+- id: 315010-000146a
+  revision: 0
+  address: ran-simulator:5226
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000146a
+    grpcport: "5226"
+    latitude: "52.078327"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 24 Cell 2
+- id: 315010-000146b
+  revision: 0
+  address: ran-simulator:5227
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000146b
+    grpcport: "5227"
+    latitude: "52.104308"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 25 Cell 0
+- id: 315010-000146c
+  revision: 0
+  address: ran-simulator:5228
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000146c
+    grpcport: "5228"
+    latitude: "52.104308"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 25 Cell 1
+- id: 315010-000146d
+  revision: 0
+  address: ran-simulator:5229
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000146d
+    grpcport: "5229"
+    latitude: "52.104308"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 25 Cell 2
+- id: 315010-000146e
+  revision: 0
+  address: ran-simulator:5230
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000146e
+    grpcport: "5230"
+    latitude: "52.130289"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 26 Cell 0
+- id: 315010-000146f
+  revision: 0
+  address: ran-simulator:5231
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000146f
+    grpcport: "5231"
+    latitude: "52.130289"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 26 Cell 1
+- id: 315010-0001470
+  revision: 0
+  address: ran-simulator:5232
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001470"
+    grpcport: "5232"
+    latitude: "52.130289"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 26 Cell 2
+- id: 315010-0001471
+  revision: 0
+  address: ran-simulator:5233
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001471"
+    grpcport: "5233"
+    latitude: "52.156269"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 27 Cell 0
+- id: 315010-0001472
+  revision: 0
+  address: ran-simulator:5234
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001472"
+    grpcport: "5234"
+    latitude: "52.156269"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 27 Cell 1
+- id: 315010-0001473
+  revision: 0
+  address: ran-simulator:5235
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001473"
+    grpcport: "5235"
+    latitude: "52.156269"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 27 Cell 2
+- id: 315010-0001474
+  revision: 0
+  address: ran-simulator:5236
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001474"
+    grpcport: "5236"
+    latitude: "52.182250"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 28 Cell 0
+- id: 315010-0001475
+  revision: 0
+  address: ran-simulator:5237
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001475"
+    grpcport: "5237"
+    latitude: "52.182250"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 28 Cell 1
+- id: 315010-0001476
+  revision: 0
+  address: ran-simulator:5238
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001476"
+    grpcport: "5238"
+    latitude: "52.182250"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 28 Cell 2
+- id: 315010-0001477
+  revision: 0
+  address: ran-simulator:5239
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001477"
+    grpcport: "5239"
+    latitude: "52.208231"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 29 Cell 0
+- id: 315010-0001478
+  revision: 0
+  address: ran-simulator:5240
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001478"
+    grpcport: "5240"
+    latitude: "52.208231"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 29 Cell 1
+- id: 315010-0001479
+  revision: 0
+  address: ran-simulator:5241
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001479"
+    grpcport: "5241"
+    latitude: "52.208231"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 29 Cell 2
+- id: 315010-000147a
+  revision: 0
+  address: ran-simulator:5242
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000147a
+    grpcport: "5242"
+    latitude: "52.234212"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 30 Cell 0
+- id: 315010-000147b
+  revision: 0
+  address: ran-simulator:5243
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000147b
+    grpcport: "5243"
+    latitude: "52.234212"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 30 Cell 1
+- id: 315010-000147c
+  revision: 0
+  address: ran-simulator:5244
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000147c
+    grpcport: "5244"
+    latitude: "52.234212"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 30 Cell 2
+- id: 315010-000147d
+  revision: 0
+  address: ran-simulator:5245
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000147d
+    grpcport: "5245"
+    latitude: "52.260192"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 31 Cell 0
+- id: 315010-000147e
+  revision: 0
+  address: ran-simulator:5246
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000147e
+    grpcport: "5246"
+    latitude: "52.260192"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 31 Cell 1
+- id: 315010-000147f
+  revision: 0
+  address: ran-simulator:5247
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000147f
+    grpcport: "5247"
+    latitude: "52.260192"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 31 Cell 2
+- id: 315010-0001480
+  revision: 0
+  address: ran-simulator:5248
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001480"
+    grpcport: "5248"
+    latitude: "52.286173"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 32 Cell 0
+- id: 315010-0001481
+  revision: 0
+  address: ran-simulator:5249
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001481"
+    grpcport: "5249"
+    latitude: "52.286173"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 32 Cell 1
+- id: 315010-0001482
+  revision: 0
+  address: ran-simulator:5250
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001482"
+    grpcport: "5250"
+    latitude: "52.286173"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 32 Cell 2
+- id: 315010-0001483
+  revision: 0
+  address: ran-simulator:5251
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001483"
+    grpcport: "5251"
+    latitude: "52.312154"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 33 Cell 0
+- id: 315010-0001484
+  revision: 0
+  address: ran-simulator:5252
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001484"
+    grpcport: "5252"
+    latitude: "52.312154"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 33 Cell 1
+- id: 315010-0001485
+  revision: 0
+  address: ran-simulator:5253
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001485"
+    grpcport: "5253"
+    latitude: "52.312154"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 33 Cell 2
+- id: 315010-0001486
+  revision: 0
+  address: ran-simulator:5254
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001486"
+    grpcport: "5254"
+    latitude: "52.338135"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 34 Cell 0
+- id: 315010-0001487
+  revision: 0
+  address: ran-simulator:5255
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001487"
+    grpcport: "5255"
+    latitude: "52.338135"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 34 Cell 1
+- id: 315010-0001488
+  revision: 0
+  address: ran-simulator:5256
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001488"
+    grpcport: "5256"
+    latitude: "52.338135"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 34 Cell 2
+- id: 315010-0001489
+  revision: 0
+  address: ran-simulator:5257
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001489"
+    grpcport: "5257"
+    latitude: "52.364115"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 35 Cell 0
+- id: 315010-000148a
+  revision: 0
+  address: ran-simulator:5258
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000148a
+    grpcport: "5258"
+    latitude: "52.364115"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 35 Cell 1
+- id: 315010-000148b
+  revision: 0
+  address: ran-simulator:5259
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000148b
+    grpcport: "5259"
+    latitude: "52.364115"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 35 Cell 2
+- id: 315010-000148c
+  revision: 0
+  address: ran-simulator:5260
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000148c
+    grpcport: "5260"
+    latitude: "52.078327"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 36 Cell 0
+- id: 315010-000148d
+  revision: 0
+  address: ran-simulator:5261
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000148d
+    grpcport: "5261"
+    latitude: "52.078327"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 36 Cell 1
+- id: 315010-000148e
+  revision: 0
+  address: ran-simulator:5262
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000148e
+    grpcport: "5262"
+    latitude: "52.078327"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 36 Cell 2
+- id: 315010-000148f
+  revision: 0
+  address: ran-simulator:5263
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000148f
+    grpcport: "5263"
+    latitude: "52.104308"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 37 Cell 0
+- id: 315010-0001490
+  revision: 0
+  address: ran-simulator:5264
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001490"
+    grpcport: "5264"
+    latitude: "52.104308"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 37 Cell 1
+- id: 315010-0001491
+  revision: 0
+  address: ran-simulator:5265
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001491"
+    grpcport: "5265"
+    latitude: "52.104308"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 37 Cell 2
+- id: 315010-0001492
+  revision: 0
+  address: ran-simulator:5266
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001492"
+    grpcport: "5266"
+    latitude: "52.130289"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 38 Cell 0
+- id: 315010-0001493
+  revision: 0
+  address: ran-simulator:5267
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001493"
+    grpcport: "5267"
+    latitude: "52.130289"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 38 Cell 1
+- id: 315010-0001494
+  revision: 0
+  address: ran-simulator:5268
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001494"
+    grpcport: "5268"
+    latitude: "52.130289"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 38 Cell 2
+- id: 315010-0001495
+  revision: 0
+  address: ran-simulator:5269
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001495"
+    grpcport: "5269"
+    latitude: "52.156269"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 39 Cell 0
+- id: 315010-0001496
+  revision: 0
+  address: ran-simulator:5270
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001496"
+    grpcport: "5270"
+    latitude: "52.156269"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 39 Cell 1
+- id: 315010-0001497
+  revision: 0
+  address: ran-simulator:5271
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001497"
+    grpcport: "5271"
+    latitude: "52.156269"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 39 Cell 2
+- id: 315010-0001498
+  revision: 0
+  address: ran-simulator:5272
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001498"
+    grpcport: "5272"
+    latitude: "52.182250"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 40 Cell 0
+- id: 315010-0001499
+  revision: 0
+  address: ran-simulator:5273
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001499"
+    grpcport: "5273"
+    latitude: "52.182250"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 40 Cell 1
+- id: 315010-000149a
+  revision: 0
+  address: ran-simulator:5274
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000149a
+    grpcport: "5274"
+    latitude: "52.182250"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 40 Cell 2
+- id: 315010-000149b
+  revision: 0
+  address: ran-simulator:5275
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000149b
+    grpcport: "5275"
+    latitude: "52.208231"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 41 Cell 0
+- id: 315010-000149c
+  revision: 0
+  address: ran-simulator:5276
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000149c
+    grpcport: "5276"
+    latitude: "52.208231"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 41 Cell 1
+- id: 315010-000149d
+  revision: 0
+  address: ran-simulator:5277
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000149d
+    grpcport: "5277"
+    latitude: "52.208231"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 41 Cell 2
+- id: 315010-000149e
+  revision: 0
+  address: ran-simulator:5278
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000149e
+    grpcport: "5278"
+    latitude: "52.234212"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 42 Cell 0
+- id: 315010-000149f
+  revision: 0
+  address: ran-simulator:5279
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000149f
+    grpcport: "5279"
+    latitude: "52.234212"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 42 Cell 1
+- id: 315010-00014a0
+  revision: 0
+  address: ran-simulator:5280
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014a0
+    grpcport: "5280"
+    latitude: "52.234212"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 42 Cell 2
+- id: 315010-00014a1
+  revision: 0
+  address: ran-simulator:5281
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014a1
+    grpcport: "5281"
+    latitude: "52.260192"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 43 Cell 0
+- id: 315010-00014a2
+  revision: 0
+  address: ran-simulator:5282
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014a2
+    grpcport: "5282"
+    latitude: "52.260192"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 43 Cell 1
+- id: 315010-00014a3
+  revision: 0
+  address: ran-simulator:5283
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014a3
+    grpcport: "5283"
+    latitude: "52.260192"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 43 Cell 2
+- id: 315010-00014a4
+  revision: 0
+  address: ran-simulator:5284
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014a4
+    grpcport: "5284"
+    latitude: "52.286173"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 44 Cell 0
+- id: 315010-00014a5
+  revision: 0
+  address: ran-simulator:5285
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014a5
+    grpcport: "5285"
+    latitude: "52.286173"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 44 Cell 1
+- id: 315010-00014a6
+  revision: 0
+  address: ran-simulator:5286
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014a6
+    grpcport: "5286"
+    latitude: "52.286173"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 44 Cell 2
+- id: 315010-00014a7
+  revision: 0
+  address: ran-simulator:5287
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014a7
+    grpcport: "5287"
+    latitude: "52.312154"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 45 Cell 0
+- id: 315010-00014a8
+  revision: 0
+  address: ran-simulator:5288
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014a8
+    grpcport: "5288"
+    latitude: "52.312154"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 45 Cell 1
+- id: 315010-00014a9
+  revision: 0
+  address: ran-simulator:5289
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014a9
+    grpcport: "5289"
+    latitude: "52.312154"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 45 Cell 2
+- id: 315010-00014aa
+  revision: 0
+  address: ran-simulator:5290
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014aa
+    grpcport: "5290"
+    latitude: "52.338135"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 46 Cell 0
+- id: 315010-00014ab
+  revision: 0
+  address: ran-simulator:5291
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014ab
+    grpcport: "5291"
+    latitude: "52.338135"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 46 Cell 1
+- id: 315010-00014ac
+  revision: 0
+  address: ran-simulator:5292
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014ac
+    grpcport: "5292"
+    latitude: "52.338135"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 46 Cell 2
+- id: 315010-00014ad
+  revision: 0
+  address: ran-simulator:5293
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014ad
+    grpcport: "5293"
+    latitude: "52.364115"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 47 Cell 0
+- id: 315010-00014ae
+  revision: 0
+  address: ran-simulator:5294
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014ae
+    grpcport: "5294"
+    latitude: "52.364115"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 47 Cell 1
+- id: 315010-00014af
+  revision: 0
+  address: ran-simulator:5295
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014af
+    grpcport: "5295"
+    latitude: "52.364115"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 47 Cell 2
+- id: 315010-00014b0
+  revision: 0
+  address: ran-simulator:5296
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014b0
+    grpcport: "5296"
+    latitude: "52.390096"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 48 Cell 0
+- id: 315010-00014b1
+  revision: 0
+  address: ran-simulator:5297
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014b1
+    grpcport: "5297"
+    latitude: "52.390096"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 48 Cell 1
+- id: 315010-00014b2
+  revision: 0
+  address: ran-simulator:5298
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014b2
+    grpcport: "5298"
+    latitude: "52.390096"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 48 Cell 2
+- id: 315010-00014b3
+  revision: 0
+  address: ran-simulator:5299
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014b3
+    grpcport: "5299"
+    latitude: "52.416077"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 49 Cell 0
+- id: 315010-00014b4
+  revision: 0
+  address: ran-simulator:5300
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014b4
+    grpcport: "5300"
+    latitude: "52.416077"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 49 Cell 1
+- id: 315010-00014b5
+  revision: 0
+  address: ran-simulator:5301
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014b5
+    grpcport: "5301"
+    latitude: "52.416077"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 49 Cell 2
+- id: 315010-00014b6
+  revision: 0
+  address: ran-simulator:5302
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014b6
+    grpcport: "5302"
+    latitude: "52.104308"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 50 Cell 0
+- id: 315010-00014b7
+  revision: 0
+  address: ran-simulator:5303
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014b7
+    grpcport: "5303"
+    latitude: "52.104308"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 50 Cell 1
+- id: 315010-00014b8
+  revision: 0
+  address: ran-simulator:5304
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014b8
+    grpcport: "5304"
+    latitude: "52.104308"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 50 Cell 2
+- id: 315010-00014b9
+  revision: 0
+  address: ran-simulator:5305
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014b9
+    grpcport: "5305"
+    latitude: "52.130289"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 51 Cell 0
+- id: 315010-00014ba
+  revision: 0
+  address: ran-simulator:5306
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014ba
+    grpcport: "5306"
+    latitude: "52.130289"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 51 Cell 1
+- id: 315010-00014bb
+  revision: 0
+  address: ran-simulator:5307
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014bb
+    grpcport: "5307"
+    latitude: "52.130289"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 51 Cell 2
+- id: 315010-00014bc
+  revision: 0
+  address: ran-simulator:5308
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014bc
+    grpcport: "5308"
+    latitude: "52.156269"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 52 Cell 0
+- id: 315010-00014bd
+  revision: 0
+  address: ran-simulator:5309
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014bd
+    grpcport: "5309"
+    latitude: "52.156269"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 52 Cell 1
+- id: 315010-00014be
+  revision: 0
+  address: ran-simulator:5310
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014be
+    grpcport: "5310"
+    latitude: "52.156269"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 52 Cell 2
+- id: 315010-00014bf
+  revision: 0
+  address: ran-simulator:5311
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014bf
+    grpcport: "5311"
+    latitude: "52.182250"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 53 Cell 0
+- id: 315010-00014c0
+  revision: 0
+  address: ran-simulator:5312
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014c0
+    grpcport: "5312"
+    latitude: "52.182250"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 53 Cell 1
+- id: 315010-00014c1
+  revision: 0
+  address: ran-simulator:5313
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014c1
+    grpcport: "5313"
+    latitude: "52.182250"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 53 Cell 2
+- id: 315010-00014c2
+  revision: 0
+  address: ran-simulator:5314
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014c2
+    grpcport: "5314"
+    latitude: "52.208231"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 54 Cell 0
+- id: 315010-00014c3
+  revision: 0
+  address: ran-simulator:5315
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014c3
+    grpcport: "5315"
+    latitude: "52.208231"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 54 Cell 1
+- id: 315010-00014c4
+  revision: 0
+  address: ran-simulator:5316
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014c4
+    grpcport: "5316"
+    latitude: "52.208231"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 54 Cell 2
+- id: 315010-00014c5
+  revision: 0
+  address: ran-simulator:5317
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014c5
+    grpcport: "5317"
+    latitude: "52.234212"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 55 Cell 0
+- id: 315010-00014c6
+  revision: 0
+  address: ran-simulator:5318
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014c6
+    grpcport: "5318"
+    latitude: "52.234212"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 55 Cell 1
+- id: 315010-00014c7
+  revision: 0
+  address: ran-simulator:5319
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014c7
+    grpcport: "5319"
+    latitude: "52.234212"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 55 Cell 2
+- id: 315010-00014c8
+  revision: 0
+  address: ran-simulator:5320
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014c8
+    grpcport: "5320"
+    latitude: "52.260192"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 56 Cell 0
+- id: 315010-00014c9
+  revision: 0
+  address: ran-simulator:5321
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014c9
+    grpcport: "5321"
+    latitude: "52.260192"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 56 Cell 1
+- id: 315010-00014ca
+  revision: 0
+  address: ran-simulator:5322
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014ca
+    grpcport: "5322"
+    latitude: "52.260192"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 56 Cell 2
+- id: 315010-00014cb
+  revision: 0
+  address: ran-simulator:5323
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014cb
+    grpcport: "5323"
+    latitude: "52.286173"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 57 Cell 0
+- id: 315010-00014cc
+  revision: 0
+  address: ran-simulator:5324
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014cc
+    grpcport: "5324"
+    latitude: "52.286173"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 57 Cell 1
+- id: 315010-00014cd
+  revision: 0
+  address: ran-simulator:5325
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014cd
+    grpcport: "5325"
+    latitude: "52.286173"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 57 Cell 2
+- id: 315010-00014ce
+  revision: 0
+  address: ran-simulator:5326
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014ce
+    grpcport: "5326"
+    latitude: "52.312154"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 58 Cell 0
+- id: 315010-00014cf
+  revision: 0
+  address: ran-simulator:5327
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014cf
+    grpcport: "5327"
+    latitude: "52.312154"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 58 Cell 1
+- id: 315010-00014d0
+  revision: 0
+  address: ran-simulator:5328
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014d0
+    grpcport: "5328"
+    latitude: "52.312154"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 58 Cell 2
+- id: 315010-00014d1
+  revision: 0
+  address: ran-simulator:5329
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014d1
+    grpcport: "5329"
+    latitude: "52.338135"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 59 Cell 0
+- id: 315010-00014d2
+  revision: 0
+  address: ran-simulator:5330
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014d2
+    grpcport: "5330"
+    latitude: "52.338135"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 59 Cell 1
+- id: 315010-00014d3
+  revision: 0
+  address: ran-simulator:5331
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014d3
+    grpcport: "5331"
+    latitude: "52.338135"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 59 Cell 2
+- id: 315010-00014d4
+  revision: 0
+  address: ran-simulator:5332
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014d4
+    grpcport: "5332"
+    latitude: "52.364115"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 60 Cell 0
+- id: 315010-00014d5
+  revision: 0
+  address: ran-simulator:5333
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014d5
+    grpcport: "5333"
+    latitude: "52.364115"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 60 Cell 1
+- id: 315010-00014d6
+  revision: 0
+  address: ran-simulator:5334
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014d6
+    grpcport: "5334"
+    latitude: "52.364115"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 60 Cell 2
+- id: 315010-00014d7
+  revision: 0
+  address: ran-simulator:5335
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014d7
+    grpcport: "5335"
+    latitude: "52.390096"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 61 Cell 0
+- id: 315010-00014d8
+  revision: 0
+  address: ran-simulator:5336
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014d8
+    grpcport: "5336"
+    latitude: "52.390096"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 61 Cell 1
+- id: 315010-00014d9
+  revision: 0
+  address: ran-simulator:5337
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014d9
+    grpcport: "5337"
+    latitude: "52.390096"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 61 Cell 2
+- id: 315010-00014da
+  revision: 0
+  address: ran-simulator:5338
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014da
+    grpcport: "5338"
+    latitude: "52.416077"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 62 Cell 0
+- id: 315010-00014db
+  revision: 0
+  address: ran-simulator:5339
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014db
+    grpcport: "5339"
+    latitude: "52.416077"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 62 Cell 1
+- id: 315010-00014dc
+  revision: 0
+  address: ran-simulator:5340
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014dc
+    grpcport: "5340"
+    latitude: "52.416077"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 62 Cell 2
+- id: 315010-00014dd
+  revision: 0
+  address: ran-simulator:5341
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014dd
+    grpcport: "5341"
+    latitude: "52.442058"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 63 Cell 0
+- id: 315010-00014de
+  revision: 0
+  address: ran-simulator:5342
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014de
+    grpcport: "5342"
+    latitude: "52.442058"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 63 Cell 1
+- id: 315010-00014df
+  revision: 0
+  address: ran-simulator:5343
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014df
+    grpcport: "5343"
+    latitude: "52.442058"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 63 Cell 2
+- id: 315010-00014e0
+  revision: 0
+  address: ran-simulator:5344
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00014e0"
+    grpcport: "5344"
+    latitude: "52.468038"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 64 Cell 0
+- id: 315010-00014e1
+  revision: 0
+  address: ran-simulator:5345
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00014e1"
+    grpcport: "5345"
+    latitude: "52.468038"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 64 Cell 1
+- id: 315010-00014e2
+  revision: 0
+  address: ran-simulator:5346
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00014e2"
+    grpcport: "5346"
+    latitude: "52.468038"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 64 Cell 2
+- id: 315010-00014e3
+  revision: 0
+  address: ran-simulator:5347
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00014e3"
+    grpcport: "5347"
+    latitude: "52.130289"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 65 Cell 0
+- id: 315010-00014e4
+  revision: 0
+  address: ran-simulator:5348
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00014e4"
+    grpcport: "5348"
+    latitude: "52.130289"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 65 Cell 1
+- id: 315010-00014e5
+  revision: 0
+  address: ran-simulator:5349
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00014e5"
+    grpcport: "5349"
+    latitude: "52.130289"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 65 Cell 2
+- id: 315010-00014e6
+  revision: 0
+  address: ran-simulator:5350
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00014e6"
+    grpcport: "5350"
+    latitude: "52.156269"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 66 Cell 0
+- id: 315010-00014e7
+  revision: 0
+  address: ran-simulator:5351
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00014e7"
+    grpcport: "5351"
+    latitude: "52.156269"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 66 Cell 1
+- id: 315010-00014e8
+  revision: 0
+  address: ran-simulator:5352
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00014e8"
+    grpcport: "5352"
+    latitude: "52.156269"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 66 Cell 2
+- id: 315010-00014e9
+  revision: 0
+  address: ran-simulator:5353
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00014e9"
+    grpcport: "5353"
+    latitude: "52.182250"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 67 Cell 0
+- id: 315010-00014ea
+  revision: 0
+  address: ran-simulator:5354
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014ea
+    grpcport: "5354"
+    latitude: "52.182250"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 67 Cell 1
+- id: 315010-00014eb
+  revision: 0
+  address: ran-simulator:5355
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014eb
+    grpcport: "5355"
+    latitude: "52.182250"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 67 Cell 2
+- id: 315010-00014ec
+  revision: 0
+  address: ran-simulator:5356
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014ec
+    grpcport: "5356"
+    latitude: "52.208231"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 68 Cell 0
+- id: 315010-00014ed
+  revision: 0
+  address: ran-simulator:5357
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014ed
+    grpcport: "5357"
+    latitude: "52.208231"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 68 Cell 1
+- id: 315010-00014ee
+  revision: 0
+  address: ran-simulator:5358
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014ee
+    grpcport: "5358"
+    latitude: "52.208231"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 68 Cell 2
+- id: 315010-00014ef
+  revision: 0
+  address: ran-simulator:5359
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014ef
+    grpcport: "5359"
+    latitude: "52.234212"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 69 Cell 0
+- id: 315010-00014f0
+  revision: 0
+  address: ran-simulator:5360
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014f0
+    grpcport: "5360"
+    latitude: "52.234212"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 69 Cell 1
+- id: 315010-00014f1
+  revision: 0
+  address: ran-simulator:5361
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014f1
+    grpcport: "5361"
+    latitude: "52.234212"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 69 Cell 2
+- id: 315010-00014f2
+  revision: 0
+  address: ran-simulator:5362
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014f2
+    grpcport: "5362"
+    latitude: "52.260192"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 70 Cell 0
+- id: 315010-00014f3
+  revision: 0
+  address: ran-simulator:5363
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014f3
+    grpcport: "5363"
+    latitude: "52.260192"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 70 Cell 1
+- id: 315010-00014f4
+  revision: 0
+  address: ran-simulator:5364
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014f4
+    grpcport: "5364"
+    latitude: "52.260192"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 70 Cell 2
+- id: 315010-00014f5
+  revision: 0
+  address: ran-simulator:5365
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014f5
+    grpcport: "5365"
+    latitude: "52.286173"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 71 Cell 0
+- id: 315010-00014f6
+  revision: 0
+  address: ran-simulator:5366
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014f6
+    grpcport: "5366"
+    latitude: "52.286173"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 71 Cell 1
+- id: 315010-00014f7
+  revision: 0
+  address: ran-simulator:5367
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014f7
+    grpcport: "5367"
+    latitude: "52.286173"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 71 Cell 2
+- id: 315010-00014f8
+  revision: 0
+  address: ran-simulator:5368
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014f8
+    grpcport: "5368"
+    latitude: "52.312154"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 72 Cell 0
+- id: 315010-00014f9
+  revision: 0
+  address: ran-simulator:5369
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014f9
+    grpcport: "5369"
+    latitude: "52.312154"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 72 Cell 1
+- id: 315010-00014fa
+  revision: 0
+  address: ran-simulator:5370
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014fa
+    grpcport: "5370"
+    latitude: "52.312154"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 72 Cell 2
+- id: 315010-00014fb
+  revision: 0
+  address: ran-simulator:5371
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014fb
+    grpcport: "5371"
+    latitude: "52.338135"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 73 Cell 0
+- id: 315010-00014fc
+  revision: 0
+  address: ran-simulator:5372
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014fc
+    grpcport: "5372"
+    latitude: "52.338135"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 73 Cell 1
+- id: 315010-00014fd
+  revision: 0
+  address: ran-simulator:5373
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00014fd
+    grpcport: "5373"
+    latitude: "52.338135"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 73 Cell 2
+- id: 315010-00014fe
+  revision: 0
+  address: ran-simulator:5374
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00014fe
+    grpcport: "5374"
+    latitude: "52.364115"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 74 Cell 0
+- id: 315010-00014ff
+  revision: 0
+  address: ran-simulator:5375
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00014ff
+    grpcport: "5375"
+    latitude: "52.364115"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 74 Cell 1
+- id: 315010-0001500
+  revision: 0
+  address: ran-simulator:5376
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001500"
+    grpcport: "5376"
+    latitude: "52.364115"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 74 Cell 2
+- id: 315010-0001501
+  revision: 0
+  address: ran-simulator:5377
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001501"
+    grpcport: "5377"
+    latitude: "52.390096"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 75 Cell 0
+- id: 315010-0001502
+  revision: 0
+  address: ran-simulator:5378
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001502"
+    grpcport: "5378"
+    latitude: "52.390096"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 75 Cell 1
+- id: 315010-0001503
+  revision: 0
+  address: ran-simulator:5379
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001503"
+    grpcport: "5379"
+    latitude: "52.390096"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 75 Cell 2
+- id: 315010-0001504
+  revision: 0
+  address: ran-simulator:5380
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001504"
+    grpcport: "5380"
+    latitude: "52.416077"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 76 Cell 0
+- id: 315010-0001505
+  revision: 0
+  address: ran-simulator:5381
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001505"
+    grpcport: "5381"
+    latitude: "52.416077"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 76 Cell 1
+- id: 315010-0001506
+  revision: 0
+  address: ran-simulator:5382
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001506"
+    grpcport: "5382"
+    latitude: "52.416077"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 76 Cell 2
+- id: 315010-0001507
+  revision: 0
+  address: ran-simulator:5383
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001507"
+    grpcport: "5383"
+    latitude: "52.442058"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 77 Cell 0
+- id: 315010-0001508
+  revision: 0
+  address: ran-simulator:5384
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001508"
+    grpcport: "5384"
+    latitude: "52.442058"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 77 Cell 1
+- id: 315010-0001509
+  revision: 0
+  address: ran-simulator:5385
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001509"
+    grpcport: "5385"
+    latitude: "52.442058"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 77 Cell 2
+- id: 315010-000150a
+  revision: 0
+  address: ran-simulator:5386
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000150a
+    grpcport: "5386"
+    latitude: "52.468038"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 78 Cell 0
+- id: 315010-000150b
+  revision: 0
+  address: ran-simulator:5387
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000150b
+    grpcport: "5387"
+    latitude: "52.468038"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 78 Cell 1
+- id: 315010-000150c
+  revision: 0
+  address: ran-simulator:5388
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000150c
+    grpcport: "5388"
+    latitude: "52.468038"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 78 Cell 2
+- id: 315010-000150d
+  revision: 0
+  address: ran-simulator:5389
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000150d
+    grpcport: "5389"
+    latitude: "52.494019"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 79 Cell 0
+- id: 315010-000150e
+  revision: 0
+  address: ran-simulator:5390
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000150e
+    grpcport: "5390"
+    latitude: "52.494019"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 79 Cell 1
+- id: 315010-000150f
+  revision: 0
+  address: ran-simulator:5391
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000150f
+    grpcport: "5391"
+    latitude: "52.494019"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 79 Cell 2
+- id: 315010-0001510
+  revision: 0
+  address: ran-simulator:5392
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001510"
+    grpcport: "5392"
+    latitude: "52.520000"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 80 Cell 0
+- id: 315010-0001511
+  revision: 0
+  address: ran-simulator:5393
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001511"
+    grpcport: "5393"
+    latitude: "52.520000"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 80 Cell 1
+- id: 315010-0001512
+  revision: 0
+  address: ran-simulator:5394
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001512"
+    grpcport: "5394"
+    latitude: "52.520000"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 80 Cell 2
+- id: 315010-0001513
+  revision: 0
+  address: ran-simulator:5395
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001513"
+    grpcport: "5395"
+    latitude: "52.156269"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 81 Cell 0
+- id: 315010-0001514
+  revision: 0
+  address: ran-simulator:5396
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001514"
+    grpcport: "5396"
+    latitude: "52.156269"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 81 Cell 1
+- id: 315010-0001515
+  revision: 0
+  address: ran-simulator:5397
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001515"
+    grpcport: "5397"
+    latitude: "52.156269"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 81 Cell 2
+- id: 315010-0001516
+  revision: 0
+  address: ran-simulator:5398
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001516"
+    grpcport: "5398"
+    latitude: "52.182250"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 82 Cell 0
+- id: 315010-0001517
+  revision: 0
+  address: ran-simulator:5399
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001517"
+    grpcport: "5399"
+    latitude: "52.182250"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 82 Cell 1
+- id: 315010-0001518
+  revision: 0
+  address: ran-simulator:5400
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001518"
+    grpcport: "5400"
+    latitude: "52.182250"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 82 Cell 2
+- id: 315010-0001519
+  revision: 0
+  address: ran-simulator:5401
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001519"
+    grpcport: "5401"
+    latitude: "52.208231"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 83 Cell 0
+- id: 315010-000151a
+  revision: 0
+  address: ran-simulator:5402
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000151a
+    grpcport: "5402"
+    latitude: "52.208231"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 83 Cell 1
+- id: 315010-000151b
+  revision: 0
+  address: ran-simulator:5403
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000151b
+    grpcport: "5403"
+    latitude: "52.208231"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 83 Cell 2
+- id: 315010-000151c
+  revision: 0
+  address: ran-simulator:5404
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000151c
+    grpcport: "5404"
+    latitude: "52.234212"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 84 Cell 0
+- id: 315010-000151d
+  revision: 0
+  address: ran-simulator:5405
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000151d
+    grpcport: "5405"
+    latitude: "52.234212"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 84 Cell 1
+- id: 315010-000151e
+  revision: 0
+  address: ran-simulator:5406
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000151e
+    grpcport: "5406"
+    latitude: "52.234212"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 84 Cell 2
+- id: 315010-000151f
+  revision: 0
+  address: ran-simulator:5407
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000151f
+    grpcport: "5407"
+    latitude: "52.260192"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 85 Cell 0
+- id: 315010-0001520
+  revision: 0
+  address: ran-simulator:5408
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001520"
+    grpcport: "5408"
+    latitude: "52.260192"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 85 Cell 1
+- id: 315010-0001521
+  revision: 0
+  address: ran-simulator:5409
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001521"
+    grpcport: "5409"
+    latitude: "52.260192"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 85 Cell 2
+- id: 315010-0001522
+  revision: 0
+  address: ran-simulator:5410
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001522"
+    grpcport: "5410"
+    latitude: "52.286173"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 86 Cell 0
+- id: 315010-0001523
+  revision: 0
+  address: ran-simulator:5411
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001523"
+    grpcport: "5411"
+    latitude: "52.286173"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 86 Cell 1
+- id: 315010-0001524
+  revision: 0
+  address: ran-simulator:5412
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001524"
+    grpcport: "5412"
+    latitude: "52.286173"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 86 Cell 2
+- id: 315010-0001525
+  revision: 0
+  address: ran-simulator:5413
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001525"
+    grpcport: "5413"
+    latitude: "52.312154"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 87 Cell 0
+- id: 315010-0001526
+  revision: 0
+  address: ran-simulator:5414
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001526"
+    grpcport: "5414"
+    latitude: "52.312154"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 87 Cell 1
+- id: 315010-0001527
+  revision: 0
+  address: ran-simulator:5415
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001527"
+    grpcport: "5415"
+    latitude: "52.312154"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 87 Cell 2
+- id: 315010-0001528
+  revision: 0
+  address: ran-simulator:5416
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001528"
+    grpcport: "5416"
+    latitude: "52.338135"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 88 Cell 0
+- id: 315010-0001529
+  revision: 0
+  address: ran-simulator:5417
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001529"
+    grpcport: "5417"
+    latitude: "52.338135"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 88 Cell 1
+- id: 315010-000152a
+  revision: 0
+  address: ran-simulator:5418
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000152a
+    grpcport: "5418"
+    latitude: "52.338135"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 88 Cell 2
+- id: 315010-000152b
+  revision: 0
+  address: ran-simulator:5419
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000152b
+    grpcport: "5419"
+    latitude: "52.364115"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 89 Cell 0
+- id: 315010-000152c
+  revision: 0
+  address: ran-simulator:5420
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000152c
+    grpcport: "5420"
+    latitude: "52.364115"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 89 Cell 1
+- id: 315010-000152d
+  revision: 0
+  address: ran-simulator:5421
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000152d
+    grpcport: "5421"
+    latitude: "52.364115"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 89 Cell 2
+- id: 315010-000152e
+  revision: 0
+  address: ran-simulator:5422
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000152e
+    grpcport: "5422"
+    latitude: "52.390096"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 90 Cell 0
+- id: 315010-000152f
+  revision: 0
+  address: ran-simulator:5423
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000152f
+    grpcport: "5423"
+    latitude: "52.390096"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 90 Cell 1
+- id: 315010-0001530
+  revision: 0
+  address: ran-simulator:5424
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001530"
+    grpcport: "5424"
+    latitude: "52.390096"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 90 Cell 2
+- id: 315010-0001531
+  revision: 0
+  address: ran-simulator:5425
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001531"
+    grpcport: "5425"
+    latitude: "52.416077"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 91 Cell 0
+- id: 315010-0001532
+  revision: 0
+  address: ran-simulator:5426
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001532"
+    grpcport: "5426"
+    latitude: "52.416077"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 91 Cell 1
+- id: 315010-0001533
+  revision: 0
+  address: ran-simulator:5427
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001533"
+    grpcport: "5427"
+    latitude: "52.416077"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 91 Cell 2
+- id: 315010-0001534
+  revision: 0
+  address: ran-simulator:5428
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001534"
+    grpcport: "5428"
+    latitude: "52.442058"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 92 Cell 0
+- id: 315010-0001535
+  revision: 0
+  address: ran-simulator:5429
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001535"
+    grpcport: "5429"
+    latitude: "52.442058"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 92 Cell 1
+- id: 315010-0001536
+  revision: 0
+  address: ran-simulator:5430
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001536"
+    grpcport: "5430"
+    latitude: "52.442058"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 92 Cell 2
+- id: 315010-0001537
+  revision: 0
+  address: ran-simulator:5431
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001537"
+    grpcport: "5431"
+    latitude: "52.468038"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 93 Cell 0
+- id: 315010-0001538
+  revision: 0
+  address: ran-simulator:5432
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001538"
+    grpcport: "5432"
+    latitude: "52.468038"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 93 Cell 1
+- id: 315010-0001539
+  revision: 0
+  address: ran-simulator:5433
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001539"
+    grpcport: "5433"
+    latitude: "52.468038"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 93 Cell 2
+- id: 315010-000153a
+  revision: 0
+  address: ran-simulator:5434
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000153a
+    grpcport: "5434"
+    latitude: "52.494019"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 94 Cell 0
+- id: 315010-000153b
+  revision: 0
+  address: ran-simulator:5435
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000153b
+    grpcport: "5435"
+    latitude: "52.494019"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 94 Cell 1
+- id: 315010-000153c
+  revision: 0
+  address: ran-simulator:5436
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000153c
+    grpcport: "5436"
+    latitude: "52.494019"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 94 Cell 2
+- id: 315010-000153d
+  revision: 0
+  address: ran-simulator:5437
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000153d
+    grpcport: "5437"
+    latitude: "52.520000"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 95 Cell 0
+- id: 315010-000153e
+  revision: 0
+  address: ran-simulator:5438
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000153e
+    grpcport: "5438"
+    latitude: "52.520000"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 95 Cell 1
+- id: 315010-000153f
+  revision: 0
+  address: ran-simulator:5439
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000153f
+    grpcport: "5439"
+    latitude: "52.520000"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 95 Cell 2
+- id: 315010-0001540
+  revision: 0
+  address: ran-simulator:5440
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001540"
+    grpcport: "5440"
+    latitude: "52.545981"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 96 Cell 0
+- id: 315010-0001541
+  revision: 0
+  address: ran-simulator:5441
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001541"
+    grpcport: "5441"
+    latitude: "52.545981"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 96 Cell 1
+- id: 315010-0001542
+  revision: 0
+  address: ran-simulator:5442
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001542"
+    grpcport: "5442"
+    latitude: "52.545981"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 96 Cell 2
+- id: 315010-0001543
+  revision: 0
+  address: ran-simulator:5443
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001543"
+    grpcport: "5443"
+    latitude: "52.571962"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 97 Cell 0
+- id: 315010-0001544
+  revision: 0
+  address: ran-simulator:5444
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001544"
+    grpcport: "5444"
+    latitude: "52.571962"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 97 Cell 1
+- id: 315010-0001545
+  revision: 0
+  address: ran-simulator:5445
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001545"
+    grpcport: "5445"
+    latitude: "52.571962"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 97 Cell 2
+- id: 315010-0001546
+  revision: 0
+  address: ran-simulator:5446
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001546"
+    grpcport: "5446"
+    latitude: "52.182250"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 98 Cell 0
+- id: 315010-0001547
+  revision: 0
+  address: ran-simulator:5447
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001547"
+    grpcport: "5447"
+    latitude: "52.182250"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 98 Cell 1
+- id: 315010-0001548
+  revision: 0
+  address: ran-simulator:5448
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001548"
+    grpcport: "5448"
+    latitude: "52.182250"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 98 Cell 2
+- id: 315010-0001549
+  revision: 0
+  address: ran-simulator:5449
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001549"
+    grpcport: "5449"
+    latitude: "52.208231"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 99 Cell 0
+- id: 315010-000154a
+  revision: 0
+  address: ran-simulator:5450
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000154a
+    grpcport: "5450"
+    latitude: "52.208231"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 99 Cell 1
+- id: 315010-000154b
+  revision: 0
+  address: ran-simulator:5451
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000154b
+    grpcport: "5451"
+    latitude: "52.208231"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 99 Cell 2
+- id: 315010-000154c
+  revision: 0
+  address: ran-simulator:5452
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000154c
+    grpcport: "5452"
+    latitude: "52.234212"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 100 Cell 0
+- id: 315010-000154d
+  revision: 0
+  address: ran-simulator:5453
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000154d
+    grpcport: "5453"
+    latitude: "52.234212"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 100 Cell 1
+- id: 315010-000154e
+  revision: 0
+  address: ran-simulator:5454
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000154e
+    grpcport: "5454"
+    latitude: "52.234212"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 100 Cell 2
+- id: 315010-000154f
+  revision: 0
+  address: ran-simulator:5455
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000154f
+    grpcport: "5455"
+    latitude: "52.260192"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 101 Cell 0
+- id: 315010-0001550
+  revision: 0
+  address: ran-simulator:5456
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001550"
+    grpcport: "5456"
+    latitude: "52.260192"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 101 Cell 1
+- id: 315010-0001551
+  revision: 0
+  address: ran-simulator:5457
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001551"
+    grpcport: "5457"
+    latitude: "52.260192"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 101 Cell 2
+- id: 315010-0001552
+  revision: 0
+  address: ran-simulator:5458
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001552"
+    grpcport: "5458"
+    latitude: "52.286173"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 102 Cell 0
+- id: 315010-0001553
+  revision: 0
+  address: ran-simulator:5459
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001553"
+    grpcport: "5459"
+    latitude: "52.286173"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 102 Cell 1
+- id: 315010-0001554
+  revision: 0
+  address: ran-simulator:5460
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001554"
+    grpcport: "5460"
+    latitude: "52.286173"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 102 Cell 2
+- id: 315010-0001555
+  revision: 0
+  address: ran-simulator:5461
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001555"
+    grpcport: "5461"
+    latitude: "52.312154"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 103 Cell 0
+- id: 315010-0001556
+  revision: 0
+  address: ran-simulator:5462
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001556"
+    grpcport: "5462"
+    latitude: "52.312154"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 103 Cell 1
+- id: 315010-0001557
+  revision: 0
+  address: ran-simulator:5463
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001557"
+    grpcport: "5463"
+    latitude: "52.312154"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 103 Cell 2
+- id: 315010-0001558
+  revision: 0
+  address: ran-simulator:5464
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001558"
+    grpcport: "5464"
+    latitude: "52.338135"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 104 Cell 0
+- id: 315010-0001559
+  revision: 0
+  address: ran-simulator:5465
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001559"
+    grpcport: "5465"
+    latitude: "52.338135"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 104 Cell 1
+- id: 315010-000155a
+  revision: 0
+  address: ran-simulator:5466
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000155a
+    grpcport: "5466"
+    latitude: "52.338135"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 104 Cell 2
+- id: 315010-000155b
+  revision: 0
+  address: ran-simulator:5467
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000155b
+    grpcport: "5467"
+    latitude: "52.364115"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 105 Cell 0
+- id: 315010-000155c
+  revision: 0
+  address: ran-simulator:5468
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000155c
+    grpcport: "5468"
+    latitude: "52.364115"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 105 Cell 1
+- id: 315010-000155d
+  revision: 0
+  address: ran-simulator:5469
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000155d
+    grpcport: "5469"
+    latitude: "52.364115"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 105 Cell 2
+- id: 315010-000155e
+  revision: 0
+  address: ran-simulator:5470
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000155e
+    grpcport: "5470"
+    latitude: "52.390096"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 106 Cell 0
+- id: 315010-000155f
+  revision: 0
+  address: ran-simulator:5471
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000155f
+    grpcport: "5471"
+    latitude: "52.390096"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 106 Cell 1
+- id: 315010-0001560
+  revision: 0
+  address: ran-simulator:5472
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001560"
+    grpcport: "5472"
+    latitude: "52.390096"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 106 Cell 2
+- id: 315010-0001561
+  revision: 0
+  address: ran-simulator:5473
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001561"
+    grpcport: "5473"
+    latitude: "52.416077"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 107 Cell 0
+- id: 315010-0001562
+  revision: 0
+  address: ran-simulator:5474
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001562"
+    grpcport: "5474"
+    latitude: "52.416077"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 107 Cell 1
+- id: 315010-0001563
+  revision: 0
+  address: ran-simulator:5475
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001563"
+    grpcport: "5475"
+    latitude: "52.416077"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 107 Cell 2
+- id: 315010-0001564
+  revision: 0
+  address: ran-simulator:5476
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001564"
+    grpcport: "5476"
+    latitude: "52.442058"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 108 Cell 0
+- id: 315010-0001565
+  revision: 0
+  address: ran-simulator:5477
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001565"
+    grpcport: "5477"
+    latitude: "52.442058"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 108 Cell 1
+- id: 315010-0001566
+  revision: 0
+  address: ran-simulator:5478
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001566"
+    grpcport: "5478"
+    latitude: "52.442058"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 108 Cell 2
+- id: 315010-0001567
+  revision: 0
+  address: ran-simulator:5479
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001567"
+    grpcport: "5479"
+    latitude: "52.468038"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 109 Cell 0
+- id: 315010-0001568
+  revision: 0
+  address: ran-simulator:5480
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001568"
+    grpcport: "5480"
+    latitude: "52.468038"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 109 Cell 1
+- id: 315010-0001569
+  revision: 0
+  address: ran-simulator:5481
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001569"
+    grpcport: "5481"
+    latitude: "52.468038"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 109 Cell 2
+- id: 315010-000156a
+  revision: 0
+  address: ran-simulator:5482
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000156a
+    grpcport: "5482"
+    latitude: "52.494019"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 110 Cell 0
+- id: 315010-000156b
+  revision: 0
+  address: ran-simulator:5483
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000156b
+    grpcport: "5483"
+    latitude: "52.494019"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 110 Cell 1
+- id: 315010-000156c
+  revision: 0
+  address: ran-simulator:5484
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000156c
+    grpcport: "5484"
+    latitude: "52.494019"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 110 Cell 2
+- id: 315010-000156d
+  revision: 0
+  address: ran-simulator:5485
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000156d
+    grpcport: "5485"
+    latitude: "52.520000"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 111 Cell 0
+- id: 315010-000156e
+  revision: 0
+  address: ran-simulator:5486
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000156e
+    grpcport: "5486"
+    latitude: "52.520000"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 111 Cell 1
+- id: 315010-000156f
+  revision: 0
+  address: ran-simulator:5487
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000156f
+    grpcport: "5487"
+    latitude: "52.520000"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 111 Cell 2
+- id: 315010-0001570
+  revision: 0
+  address: ran-simulator:5488
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001570"
+    grpcport: "5488"
+    latitude: "52.545981"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 112 Cell 0
+- id: 315010-0001571
+  revision: 0
+  address: ran-simulator:5489
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001571"
+    grpcport: "5489"
+    latitude: "52.545981"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 112 Cell 1
+- id: 315010-0001572
+  revision: 0
+  address: ran-simulator:5490
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001572"
+    grpcport: "5490"
+    latitude: "52.545981"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 112 Cell 2
+- id: 315010-0001573
+  revision: 0
+  address: ran-simulator:5491
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001573"
+    grpcport: "5491"
+    latitude: "52.571962"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 113 Cell 0
+- id: 315010-0001574
+  revision: 0
+  address: ran-simulator:5492
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001574"
+    grpcport: "5492"
+    latitude: "52.571962"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 113 Cell 1
+- id: 315010-0001575
+  revision: 0
+  address: ran-simulator:5493
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001575"
+    grpcport: "5493"
+    latitude: "52.571962"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 113 Cell 2
+- id: 315010-0001576
+  revision: 0
+  address: ran-simulator:5494
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001576"
+    grpcport: "5494"
+    latitude: "52.597942"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 114 Cell 0
+- id: 315010-0001577
+  revision: 0
+  address: ran-simulator:5495
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001577"
+    grpcport: "5495"
+    latitude: "52.597942"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 114 Cell 1
+- id: 315010-0001578
+  revision: 0
+  address: ran-simulator:5496
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001578"
+    grpcport: "5496"
+    latitude: "52.597942"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 114 Cell 2
+- id: 315010-0001579
+  revision: 0
+  address: ran-simulator:5497
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001579"
+    grpcport: "5497"
+    latitude: "52.623923"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 115 Cell 0
+- id: 315010-000157a
+  revision: 0
+  address: ran-simulator:5498
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000157a
+    grpcport: "5498"
+    latitude: "52.623923"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 115 Cell 1
+- id: 315010-000157b
+  revision: 0
+  address: ran-simulator:5499
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000157b
+    grpcport: "5499"
+    latitude: "52.623923"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 115 Cell 2
+- id: 315010-000157c
+  revision: 0
+  address: ran-simulator:5500
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000157c
+    grpcport: "5500"
+    latitude: "52.208231"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 116 Cell 0
+- id: 315010-000157d
+  revision: 0
+  address: ran-simulator:5501
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000157d
+    grpcport: "5501"
+    latitude: "52.208231"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 116 Cell 1
+- id: 315010-000157e
+  revision: 0
+  address: ran-simulator:5502
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000157e
+    grpcport: "5502"
+    latitude: "52.208231"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 116 Cell 2
+- id: 315010-000157f
+  revision: 0
+  address: ran-simulator:5503
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000157f
+    grpcport: "5503"
+    latitude: "52.234212"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 117 Cell 0
+- id: 315010-0001580
+  revision: 0
+  address: ran-simulator:5504
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001580"
+    grpcport: "5504"
+    latitude: "52.234212"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 117 Cell 1
+- id: 315010-0001581
+  revision: 0
+  address: ran-simulator:5505
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001581"
+    grpcport: "5505"
+    latitude: "52.234212"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 117 Cell 2
+- id: 315010-0001582
+  revision: 0
+  address: ran-simulator:5506
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001582"
+    grpcport: "5506"
+    latitude: "52.260192"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 118 Cell 0
+- id: 315010-0001583
+  revision: 0
+  address: ran-simulator:5507
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001583"
+    grpcport: "5507"
+    latitude: "52.260192"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 118 Cell 1
+- id: 315010-0001584
+  revision: 0
+  address: ran-simulator:5508
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001584"
+    grpcport: "5508"
+    latitude: "52.260192"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 118 Cell 2
+- id: 315010-0001585
+  revision: 0
+  address: ran-simulator:5509
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001585"
+    grpcport: "5509"
+    latitude: "52.286173"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 119 Cell 0
+- id: 315010-0001586
+  revision: 0
+  address: ran-simulator:5510
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001586"
+    grpcport: "5510"
+    latitude: "52.286173"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 119 Cell 1
+- id: 315010-0001587
+  revision: 0
+  address: ran-simulator:5511
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001587"
+    grpcport: "5511"
+    latitude: "52.286173"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 119 Cell 2
+- id: 315010-0001588
+  revision: 0
+  address: ran-simulator:5512
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001588"
+    grpcport: "5512"
+    latitude: "52.312154"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 120 Cell 0
+- id: 315010-0001589
+  revision: 0
+  address: ran-simulator:5513
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001589"
+    grpcport: "5513"
+    latitude: "52.312154"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 120 Cell 1
+- id: 315010-000158a
+  revision: 0
+  address: ran-simulator:5514
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000158a
+    grpcport: "5514"
+    latitude: "52.312154"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 120 Cell 2
+- id: 315010-000158b
+  revision: 0
+  address: ran-simulator:5515
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000158b
+    grpcport: "5515"
+    latitude: "52.338135"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 121 Cell 0
+- id: 315010-000158c
+  revision: 0
+  address: ran-simulator:5516
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000158c
+    grpcport: "5516"
+    latitude: "52.338135"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 121 Cell 1
+- id: 315010-000158d
+  revision: 0
+  address: ran-simulator:5517
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000158d
+    grpcport: "5517"
+    latitude: "52.338135"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 121 Cell 2
+- id: 315010-000158e
+  revision: 0
+  address: ran-simulator:5518
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000158e
+    grpcport: "5518"
+    latitude: "52.364115"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 122 Cell 0
+- id: 315010-000158f
+  revision: 0
+  address: ran-simulator:5519
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000158f
+    grpcport: "5519"
+    latitude: "52.364115"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 122 Cell 1
+- id: 315010-0001590
+  revision: 0
+  address: ran-simulator:5520
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001590"
+    grpcport: "5520"
+    latitude: "52.364115"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 122 Cell 2
+- id: 315010-0001591
+  revision: 0
+  address: ran-simulator:5521
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001591"
+    grpcport: "5521"
+    latitude: "52.390096"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 123 Cell 0
+- id: 315010-0001592
+  revision: 0
+  address: ran-simulator:5522
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001592"
+    grpcport: "5522"
+    latitude: "52.390096"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 123 Cell 1
+- id: 315010-0001593
+  revision: 0
+  address: ran-simulator:5523
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001593"
+    grpcport: "5523"
+    latitude: "52.390096"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 123 Cell 2
+- id: 315010-0001594
+  revision: 0
+  address: ran-simulator:5524
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001594"
+    grpcport: "5524"
+    latitude: "52.416077"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 124 Cell 0
+- id: 315010-0001595
+  revision: 0
+  address: ran-simulator:5525
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001595"
+    grpcport: "5525"
+    latitude: "52.416077"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 124 Cell 1
+- id: 315010-0001596
+  revision: 0
+  address: ran-simulator:5526
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001596"
+    grpcport: "5526"
+    latitude: "52.416077"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 124 Cell 2
+- id: 315010-0001597
+  revision: 0
+  address: ran-simulator:5527
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001597"
+    grpcport: "5527"
+    latitude: "52.442058"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 125 Cell 0
+- id: 315010-0001598
+  revision: 0
+  address: ran-simulator:5528
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001598"
+    grpcport: "5528"
+    latitude: "52.442058"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 125 Cell 1
+- id: 315010-0001599
+  revision: 0
+  address: ran-simulator:5529
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001599"
+    grpcport: "5529"
+    latitude: "52.442058"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 125 Cell 2
+- id: 315010-000159a
+  revision: 0
+  address: ran-simulator:5530
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000159a
+    grpcport: "5530"
+    latitude: "52.468038"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 126 Cell 0
+- id: 315010-000159b
+  revision: 0
+  address: ran-simulator:5531
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000159b
+    grpcport: "5531"
+    latitude: "52.468038"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 126 Cell 1
+- id: 315010-000159c
+  revision: 0
+  address: ran-simulator:5532
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000159c
+    grpcport: "5532"
+    latitude: "52.468038"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 126 Cell 2
+- id: 315010-000159d
+  revision: 0
+  address: ran-simulator:5533
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000159d
+    grpcport: "5533"
+    latitude: "52.494019"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 127 Cell 0
+- id: 315010-000159e
+  revision: 0
+  address: ran-simulator:5534
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000159e
+    grpcport: "5534"
+    latitude: "52.494019"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 127 Cell 1
+- id: 315010-000159f
+  revision: 0
+  address: ran-simulator:5535
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000159f
+    grpcport: "5535"
+    latitude: "52.494019"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 127 Cell 2
+- id: 315010-00015a0
+  revision: 0
+  address: ran-simulator:5536
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015a0
+    grpcport: "5536"
+    latitude: "52.520000"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 128 Cell 0
+- id: 315010-00015a1
+  revision: 0
+  address: ran-simulator:5537
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015a1
+    grpcport: "5537"
+    latitude: "52.520000"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 128 Cell 1
+- id: 315010-00015a2
+  revision: 0
+  address: ran-simulator:5538
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015a2
+    grpcport: "5538"
+    latitude: "52.520000"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 128 Cell 2
+- id: 315010-00015a3
+  revision: 0
+  address: ran-simulator:5539
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015a3
+    grpcport: "5539"
+    latitude: "52.545981"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 129 Cell 0
+- id: 315010-00015a4
+  revision: 0
+  address: ran-simulator:5540
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015a4
+    grpcport: "5540"
+    latitude: "52.545981"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 129 Cell 1
+- id: 315010-00015a5
+  revision: 0
+  address: ran-simulator:5541
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015a5
+    grpcport: "5541"
+    latitude: "52.545981"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 129 Cell 2
+- id: 315010-00015a6
+  revision: 0
+  address: ran-simulator:5542
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015a6
+    grpcport: "5542"
+    latitude: "52.571962"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 130 Cell 0
+- id: 315010-00015a7
+  revision: 0
+  address: ran-simulator:5543
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015a7
+    grpcport: "5543"
+    latitude: "52.571962"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 130 Cell 1
+- id: 315010-00015a8
+  revision: 0
+  address: ran-simulator:5544
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015a8
+    grpcport: "5544"
+    latitude: "52.571962"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 130 Cell 2
+- id: 315010-00015a9
+  revision: 0
+  address: ran-simulator:5545
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015a9
+    grpcport: "5545"
+    latitude: "52.597942"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 131 Cell 0
+- id: 315010-00015aa
+  revision: 0
+  address: ran-simulator:5546
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015aa
+    grpcport: "5546"
+    latitude: "52.597942"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 131 Cell 1
+- id: 315010-00015ab
+  revision: 0
+  address: ran-simulator:5547
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015ab
+    grpcport: "5547"
+    latitude: "52.597942"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 131 Cell 2
+- id: 315010-00015ac
+  revision: 0
+  address: ran-simulator:5548
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015ac
+    grpcport: "5548"
+    latitude: "52.623923"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 132 Cell 0
+- id: 315010-00015ad
+  revision: 0
+  address: ran-simulator:5549
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015ad
+    grpcport: "5549"
+    latitude: "52.623923"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 132 Cell 1
+- id: 315010-00015ae
+  revision: 0
+  address: ran-simulator:5550
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015ae
+    grpcport: "5550"
+    latitude: "52.623923"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 132 Cell 2
+- id: 315010-00015af
+  revision: 0
+  address: ran-simulator:5551
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015af
+    grpcport: "5551"
+    latitude: "52.649904"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 133 Cell 0
+- id: 315010-00015b0
+  revision: 0
+  address: ran-simulator:5552
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015b0
+    grpcport: "5552"
+    latitude: "52.649904"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 133 Cell 1
+- id: 315010-00015b1
+  revision: 0
+  address: ran-simulator:5553
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015b1
+    grpcport: "5553"
+    latitude: "52.649904"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 133 Cell 2
+- id: 315010-00015b2
+  revision: 0
+  address: ran-simulator:5554
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015b2
+    grpcport: "5554"
+    latitude: "52.675885"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 134 Cell 0
+- id: 315010-00015b3
+  revision: 0
+  address: ran-simulator:5555
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015b3
+    grpcport: "5555"
+    latitude: "52.675885"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 134 Cell 1
+- id: 315010-00015b4
+  revision: 0
+  address: ran-simulator:5556
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015b4
+    grpcport: "5556"
+    latitude: "52.675885"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 134 Cell 2
+- id: 315010-00015b5
+  revision: 0
+  address: ran-simulator:5557
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015b5
+    grpcport: "5557"
+    latitude: "52.234212"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 135 Cell 0
+- id: 315010-00015b6
+  revision: 0
+  address: ran-simulator:5558
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015b6
+    grpcport: "5558"
+    latitude: "52.234212"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 135 Cell 1
+- id: 315010-00015b7
+  revision: 0
+  address: ran-simulator:5559
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015b7
+    grpcport: "5559"
+    latitude: "52.234212"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 135 Cell 2
+- id: 315010-00015b8
+  revision: 0
+  address: ran-simulator:5560
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015b8
+    grpcport: "5560"
+    latitude: "52.260192"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 136 Cell 0
+- id: 315010-00015b9
+  revision: 0
+  address: ran-simulator:5561
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015b9
+    grpcport: "5561"
+    latitude: "52.260192"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 136 Cell 1
+- id: 315010-00015ba
+  revision: 0
+  address: ran-simulator:5562
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015ba
+    grpcport: "5562"
+    latitude: "52.260192"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 136 Cell 2
+- id: 315010-00015bb
+  revision: 0
+  address: ran-simulator:5563
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015bb
+    grpcport: "5563"
+    latitude: "52.286173"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 137 Cell 0
+- id: 315010-00015bc
+  revision: 0
+  address: ran-simulator:5564
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015bc
+    grpcport: "5564"
+    latitude: "52.286173"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 137 Cell 1
+- id: 315010-00015bd
+  revision: 0
+  address: ran-simulator:5565
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015bd
+    grpcport: "5565"
+    latitude: "52.286173"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 137 Cell 2
+- id: 315010-00015be
+  revision: 0
+  address: ran-simulator:5566
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015be
+    grpcport: "5566"
+    latitude: "52.312154"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 138 Cell 0
+- id: 315010-00015bf
+  revision: 0
+  address: ran-simulator:5567
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015bf
+    grpcport: "5567"
+    latitude: "52.312154"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 138 Cell 1
+- id: 315010-00015c0
+  revision: 0
+  address: ran-simulator:5568
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015c0
+    grpcport: "5568"
+    latitude: "52.312154"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 138 Cell 2
+- id: 315010-00015c1
+  revision: 0
+  address: ran-simulator:5569
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015c1
+    grpcport: "5569"
+    latitude: "52.338135"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 139 Cell 0
+- id: 315010-00015c2
+  revision: 0
+  address: ran-simulator:5570
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015c2
+    grpcport: "5570"
+    latitude: "52.338135"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 139 Cell 1
+- id: 315010-00015c3
+  revision: 0
+  address: ran-simulator:5571
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015c3
+    grpcport: "5571"
+    latitude: "52.338135"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 139 Cell 2
+- id: 315010-00015c4
+  revision: 0
+  address: ran-simulator:5572
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015c4
+    grpcport: "5572"
+    latitude: "52.364115"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 140 Cell 0
+- id: 315010-00015c5
+  revision: 0
+  address: ran-simulator:5573
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015c5
+    grpcport: "5573"
+    latitude: "52.364115"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 140 Cell 1
+- id: 315010-00015c6
+  revision: 0
+  address: ran-simulator:5574
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015c6
+    grpcport: "5574"
+    latitude: "52.364115"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 140 Cell 2
+- id: 315010-00015c7
+  revision: 0
+  address: ran-simulator:5575
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015c7
+    grpcport: "5575"
+    latitude: "52.390096"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 141 Cell 0
+- id: 315010-00015c8
+  revision: 0
+  address: ran-simulator:5576
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015c8
+    grpcport: "5576"
+    latitude: "52.390096"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 141 Cell 1
+- id: 315010-00015c9
+  revision: 0
+  address: ran-simulator:5577
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015c9
+    grpcport: "5577"
+    latitude: "52.390096"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 141 Cell 2
+- id: 315010-00015ca
+  revision: 0
+  address: ran-simulator:5578
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015ca
+    grpcport: "5578"
+    latitude: "52.416077"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 142 Cell 0
+- id: 315010-00015cb
+  revision: 0
+  address: ran-simulator:5579
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015cb
+    grpcport: "5579"
+    latitude: "52.416077"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 142 Cell 1
+- id: 315010-00015cc
+  revision: 0
+  address: ran-simulator:5580
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015cc
+    grpcport: "5580"
+    latitude: "52.416077"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 142 Cell 2
+- id: 315010-00015cd
+  revision: 0
+  address: ran-simulator:5581
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015cd
+    grpcport: "5581"
+    latitude: "52.442058"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 143 Cell 0
+- id: 315010-00015ce
+  revision: 0
+  address: ran-simulator:5582
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015ce
+    grpcport: "5582"
+    latitude: "52.442058"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 143 Cell 1
+- id: 315010-00015cf
+  revision: 0
+  address: ran-simulator:5583
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015cf
+    grpcport: "5583"
+    latitude: "52.442058"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 143 Cell 2
+- id: 315010-00015d0
+  revision: 0
+  address: ran-simulator:5584
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015d0
+    grpcport: "5584"
+    latitude: "52.468038"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 144 Cell 0
+- id: 315010-00015d1
+  revision: 0
+  address: ran-simulator:5585
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015d1
+    grpcport: "5585"
+    latitude: "52.468038"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 144 Cell 1
+- id: 315010-00015d2
+  revision: 0
+  address: ran-simulator:5586
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015d2
+    grpcport: "5586"
+    latitude: "52.468038"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 144 Cell 2
+- id: 315010-00015d3
+  revision: 0
+  address: ran-simulator:5587
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015d3
+    grpcport: "5587"
+    latitude: "52.494019"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 145 Cell 0
+- id: 315010-00015d4
+  revision: 0
+  address: ran-simulator:5588
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015d4
+    grpcport: "5588"
+    latitude: "52.494019"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 145 Cell 1
+- id: 315010-00015d5
+  revision: 0
+  address: ran-simulator:5589
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015d5
+    grpcport: "5589"
+    latitude: "52.494019"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 145 Cell 2
+- id: 315010-00015d6
+  revision: 0
+  address: ran-simulator:5590
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015d6
+    grpcport: "5590"
+    latitude: "52.520000"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 146 Cell 0
+- id: 315010-00015d7
+  revision: 0
+  address: ran-simulator:5591
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015d7
+    grpcport: "5591"
+    latitude: "52.520000"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 146 Cell 1
+- id: 315010-00015d8
+  revision: 0
+  address: ran-simulator:5592
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015d8
+    grpcport: "5592"
+    latitude: "52.520000"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 146 Cell 2
+- id: 315010-00015d9
+  revision: 0
+  address: ran-simulator:5593
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015d9
+    grpcport: "5593"
+    latitude: "52.545981"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 147 Cell 0
+- id: 315010-00015da
+  revision: 0
+  address: ran-simulator:5594
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015da
+    grpcport: "5594"
+    latitude: "52.545981"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 147 Cell 1
+- id: 315010-00015db
+  revision: 0
+  address: ran-simulator:5595
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015db
+    grpcport: "5595"
+    latitude: "52.545981"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 147 Cell 2
+- id: 315010-00015dc
+  revision: 0
+  address: ran-simulator:5596
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015dc
+    grpcport: "5596"
+    latitude: "52.571962"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 148 Cell 0
+- id: 315010-00015dd
+  revision: 0
+  address: ran-simulator:5597
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015dd
+    grpcport: "5597"
+    latitude: "52.571962"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 148 Cell 1
+- id: 315010-00015de
+  revision: 0
+  address: ran-simulator:5598
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015de
+    grpcport: "5598"
+    latitude: "52.571962"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 148 Cell 2
+- id: 315010-00015df
+  revision: 0
+  address: ran-simulator:5599
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015df
+    grpcport: "5599"
+    latitude: "52.597942"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 149 Cell 0
+- id: 315010-00015e0
+  revision: 0
+  address: ran-simulator:5600
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00015e0"
+    grpcport: "5600"
+    latitude: "52.597942"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 149 Cell 1
+- id: 315010-00015e1
+  revision: 0
+  address: ran-simulator:5601
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00015e1"
+    grpcport: "5601"
+    latitude: "52.597942"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 149 Cell 2
+- id: 315010-00015e2
+  revision: 0
+  address: ran-simulator:5602
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00015e2"
+    grpcport: "5602"
+    latitude: "52.623923"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 150 Cell 0
+- id: 315010-00015e3
+  revision: 0
+  address: ran-simulator:5603
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00015e3"
+    grpcport: "5603"
+    latitude: "52.623923"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 150 Cell 1
+- id: 315010-00015e4
+  revision: 0
+  address: ran-simulator:5604
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00015e4"
+    grpcport: "5604"
+    latitude: "52.623923"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 150 Cell 2
+- id: 315010-00015e5
+  revision: 0
+  address: ran-simulator:5605
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00015e5"
+    grpcport: "5605"
+    latitude: "52.649904"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 151 Cell 0
+- id: 315010-00015e6
+  revision: 0
+  address: ran-simulator:5606
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00015e6"
+    grpcport: "5606"
+    latitude: "52.649904"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 151 Cell 1
+- id: 315010-00015e7
+  revision: 0
+  address: ran-simulator:5607
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00015e7"
+    grpcport: "5607"
+    latitude: "52.649904"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 151 Cell 2
+- id: 315010-00015e8
+  revision: 0
+  address: ran-simulator:5608
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00015e8"
+    grpcport: "5608"
+    latitude: "52.675885"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 152 Cell 0
+- id: 315010-00015e9
+  revision: 0
+  address: ran-simulator:5609
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00015e9"
+    grpcport: "5609"
+    latitude: "52.675885"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 152 Cell 1
+- id: 315010-00015ea
+  revision: 0
+  address: ran-simulator:5610
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015ea
+    grpcport: "5610"
+    latitude: "52.675885"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 152 Cell 2
+- id: 315010-00015eb
+  revision: 0
+  address: ran-simulator:5611
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015eb
+    grpcport: "5611"
+    latitude: "52.701865"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 153 Cell 0
+- id: 315010-00015ec
+  revision: 0
+  address: ran-simulator:5612
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015ec
+    grpcport: "5612"
+    latitude: "52.701865"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 153 Cell 1
+- id: 315010-00015ed
+  revision: 0
+  address: ran-simulator:5613
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015ed
+    grpcport: "5613"
+    latitude: "52.701865"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 153 Cell 2
+- id: 315010-00015ee
+  revision: 0
+  address: ran-simulator:5614
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015ee
+    grpcport: "5614"
+    latitude: "52.727846"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 154 Cell 0
+- id: 315010-00015ef
+  revision: 0
+  address: ran-simulator:5615
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015ef
+    grpcport: "5615"
+    latitude: "52.727846"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 154 Cell 1
+- id: 315010-00015f0
+  revision: 0
+  address: ran-simulator:5616
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015f0
+    grpcport: "5616"
+    latitude: "52.727846"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 154 Cell 2
+- id: 315010-00015f1
+  revision: 0
+  address: ran-simulator:5617
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015f1
+    grpcport: "5617"
+    latitude: "52.260192"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 155 Cell 0
+- id: 315010-00015f2
+  revision: 0
+  address: ran-simulator:5618
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015f2
+    grpcport: "5618"
+    latitude: "52.260192"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 155 Cell 1
+- id: 315010-00015f3
+  revision: 0
+  address: ran-simulator:5619
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015f3
+    grpcport: "5619"
+    latitude: "52.260192"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 155 Cell 2
+- id: 315010-00015f4
+  revision: 0
+  address: ran-simulator:5620
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015f4
+    grpcport: "5620"
+    latitude: "52.286173"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 156 Cell 0
+- id: 315010-00015f5
+  revision: 0
+  address: ran-simulator:5621
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015f5
+    grpcport: "5621"
+    latitude: "52.286173"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 156 Cell 1
+- id: 315010-00015f6
+  revision: 0
+  address: ran-simulator:5622
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015f6
+    grpcport: "5622"
+    latitude: "52.286173"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 156 Cell 2
+- id: 315010-00015f7
+  revision: 0
+  address: ran-simulator:5623
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015f7
+    grpcport: "5623"
+    latitude: "52.312154"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 157 Cell 0
+- id: 315010-00015f8
+  revision: 0
+  address: ran-simulator:5624
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015f8
+    grpcport: "5624"
+    latitude: "52.312154"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 157 Cell 1
+- id: 315010-00015f9
+  revision: 0
+  address: ran-simulator:5625
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015f9
+    grpcport: "5625"
+    latitude: "52.312154"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 157 Cell 2
+- id: 315010-00015fa
+  revision: 0
+  address: ran-simulator:5626
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015fa
+    grpcport: "5626"
+    latitude: "52.338135"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 158 Cell 0
+- id: 315010-00015fb
+  revision: 0
+  address: ran-simulator:5627
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015fb
+    grpcport: "5627"
+    latitude: "52.338135"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 158 Cell 1
+- id: 315010-00015fc
+  revision: 0
+  address: ran-simulator:5628
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015fc
+    grpcport: "5628"
+    latitude: "52.338135"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 158 Cell 2
+- id: 315010-00015fd
+  revision: 0
+  address: ran-simulator:5629
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00015fd
+    grpcport: "5629"
+    latitude: "52.364115"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 159 Cell 0
+- id: 315010-00015fe
+  revision: 0
+  address: ran-simulator:5630
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00015fe
+    grpcport: "5630"
+    latitude: "52.364115"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 159 Cell 1
+- id: 315010-00015ff
+  revision: 0
+  address: ran-simulator:5631
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00015ff
+    grpcport: "5631"
+    latitude: "52.364115"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 159 Cell 2
+- id: 315010-0001600
+  revision: 0
+  address: ran-simulator:5632
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001600"
+    grpcport: "5632"
+    latitude: "52.390096"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 160 Cell 0
+- id: 315010-0001601
+  revision: 0
+  address: ran-simulator:5633
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001601"
+    grpcport: "5633"
+    latitude: "52.390096"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 160 Cell 1
+- id: 315010-0001602
+  revision: 0
+  address: ran-simulator:5634
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001602"
+    grpcport: "5634"
+    latitude: "52.390096"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 160 Cell 2
+- id: 315010-0001603
+  revision: 0
+  address: ran-simulator:5635
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001603"
+    grpcport: "5635"
+    latitude: "52.416077"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 161 Cell 0
+- id: 315010-0001604
+  revision: 0
+  address: ran-simulator:5636
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001604"
+    grpcport: "5636"
+    latitude: "52.416077"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 161 Cell 1
+- id: 315010-0001605
+  revision: 0
+  address: ran-simulator:5637
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001605"
+    grpcport: "5637"
+    latitude: "52.416077"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 161 Cell 2
+- id: 315010-0001606
+  revision: 0
+  address: ran-simulator:5638
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001606"
+    grpcport: "5638"
+    latitude: "52.442058"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 162 Cell 0
+- id: 315010-0001607
+  revision: 0
+  address: ran-simulator:5639
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001607"
+    grpcport: "5639"
+    latitude: "52.442058"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 162 Cell 1
+- id: 315010-0001608
+  revision: 0
+  address: ran-simulator:5640
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001608"
+    grpcport: "5640"
+    latitude: "52.442058"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 162 Cell 2
+- id: 315010-0001609
+  revision: 0
+  address: ran-simulator:5641
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001609"
+    grpcport: "5641"
+    latitude: "52.468038"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 163 Cell 0
+- id: 315010-000160a
+  revision: 0
+  address: ran-simulator:5642
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000160a
+    grpcport: "5642"
+    latitude: "52.468038"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 163 Cell 1
+- id: 315010-000160b
+  revision: 0
+  address: ran-simulator:5643
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000160b
+    grpcport: "5643"
+    latitude: "52.468038"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 163 Cell 2
+- id: 315010-000160c
+  revision: 0
+  address: ran-simulator:5644
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000160c
+    grpcport: "5644"
+    latitude: "52.494019"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 164 Cell 0
+- id: 315010-000160d
+  revision: 0
+  address: ran-simulator:5645
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000160d
+    grpcport: "5645"
+    latitude: "52.494019"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 164 Cell 1
+- id: 315010-000160e
+  revision: 0
+  address: ran-simulator:5646
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000160e
+    grpcport: "5646"
+    latitude: "52.494019"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 164 Cell 2
+- id: 315010-000160f
+  revision: 0
+  address: ran-simulator:5647
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000160f
+    grpcport: "5647"
+    latitude: "52.520000"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 165 Cell 0
+- id: 315010-0001610
+  revision: 0
+  address: ran-simulator:5648
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001610"
+    grpcport: "5648"
+    latitude: "52.520000"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 165 Cell 1
+- id: 315010-0001611
+  revision: 0
+  address: ran-simulator:5649
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001611"
+    grpcport: "5649"
+    latitude: "52.520000"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 165 Cell 2
+- id: 315010-0001612
+  revision: 0
+  address: ran-simulator:5650
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001612"
+    grpcport: "5650"
+    latitude: "52.545981"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 166 Cell 0
+- id: 315010-0001613
+  revision: 0
+  address: ran-simulator:5651
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001613"
+    grpcport: "5651"
+    latitude: "52.545981"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 166 Cell 1
+- id: 315010-0001614
+  revision: 0
+  address: ran-simulator:5652
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001614"
+    grpcport: "5652"
+    latitude: "52.545981"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 166 Cell 2
+- id: 315010-0001615
+  revision: 0
+  address: ran-simulator:5653
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001615"
+    grpcport: "5653"
+    latitude: "52.571962"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 167 Cell 0
+- id: 315010-0001616
+  revision: 0
+  address: ran-simulator:5654
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001616"
+    grpcport: "5654"
+    latitude: "52.571962"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 167 Cell 1
+- id: 315010-0001617
+  revision: 0
+  address: ran-simulator:5655
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001617"
+    grpcport: "5655"
+    latitude: "52.571962"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 167 Cell 2
+- id: 315010-0001618
+  revision: 0
+  address: ran-simulator:5656
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001618"
+    grpcport: "5656"
+    latitude: "52.597942"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 168 Cell 0
+- id: 315010-0001619
+  revision: 0
+  address: ran-simulator:5657
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001619"
+    grpcport: "5657"
+    latitude: "52.597942"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 168 Cell 1
+- id: 315010-000161a
+  revision: 0
+  address: ran-simulator:5658
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000161a
+    grpcport: "5658"
+    latitude: "52.597942"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 168 Cell 2
+- id: 315010-000161b
+  revision: 0
+  address: ran-simulator:5659
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000161b
+    grpcport: "5659"
+    latitude: "52.623923"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 169 Cell 0
+- id: 315010-000161c
+  revision: 0
+  address: ran-simulator:5660
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000161c
+    grpcport: "5660"
+    latitude: "52.623923"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 169 Cell 1
+- id: 315010-000161d
+  revision: 0
+  address: ran-simulator:5661
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000161d
+    grpcport: "5661"
+    latitude: "52.623923"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 169 Cell 2
+- id: 315010-000161e
+  revision: 0
+  address: ran-simulator:5662
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000161e
+    grpcport: "5662"
+    latitude: "52.649904"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 170 Cell 0
+- id: 315010-000161f
+  revision: 0
+  address: ran-simulator:5663
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000161f
+    grpcport: "5663"
+    latitude: "52.649904"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 170 Cell 1
+- id: 315010-0001620
+  revision: 0
+  address: ran-simulator:5664
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001620"
+    grpcport: "5664"
+    latitude: "52.649904"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 170 Cell 2
+- id: 315010-0001621
+  revision: 0
+  address: ran-simulator:5665
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001621"
+    grpcport: "5665"
+    latitude: "52.675885"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 171 Cell 0
+- id: 315010-0001622
+  revision: 0
+  address: ran-simulator:5666
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001622"
+    grpcport: "5666"
+    latitude: "52.675885"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 171 Cell 1
+- id: 315010-0001623
+  revision: 0
+  address: ran-simulator:5667
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001623"
+    grpcport: "5667"
+    latitude: "52.675885"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 171 Cell 2
+- id: 315010-0001624
+  revision: 0
+  address: ran-simulator:5668
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001624"
+    grpcport: "5668"
+    latitude: "52.701865"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 172 Cell 0
+- id: 315010-0001625
+  revision: 0
+  address: ran-simulator:5669
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001625"
+    grpcport: "5669"
+    latitude: "52.701865"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 172 Cell 1
+- id: 315010-0001626
+  revision: 0
+  address: ran-simulator:5670
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001626"
+    grpcport: "5670"
+    latitude: "52.701865"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 172 Cell 2
+- id: 315010-0001627
+  revision: 0
+  address: ran-simulator:5671
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001627"
+    grpcport: "5671"
+    latitude: "52.727846"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 173 Cell 0
+- id: 315010-0001628
+  revision: 0
+  address: ran-simulator:5672
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001628"
+    grpcport: "5672"
+    latitude: "52.727846"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 173 Cell 1
+- id: 315010-0001629
+  revision: 0
+  address: ran-simulator:5673
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001629"
+    grpcport: "5673"
+    latitude: "52.727846"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 173 Cell 2
+- id: 315010-000162a
+  revision: 0
+  address: ran-simulator:5674
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000162a
+    grpcport: "5674"
+    latitude: "52.753827"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 174 Cell 0
+- id: 315010-000162b
+  revision: 0
+  address: ran-simulator:5675
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000162b
+    grpcport: "5675"
+    latitude: "52.753827"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 174 Cell 1
+- id: 315010-000162c
+  revision: 0
+  address: ran-simulator:5676
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000162c
+    grpcport: "5676"
+    latitude: "52.753827"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 174 Cell 2
+- id: 315010-000162d
+  revision: 0
+  address: ran-simulator:5677
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000162d
+    grpcport: "5677"
+    latitude: "52.779808"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 175 Cell 0
+- id: 315010-000162e
+  revision: 0
+  address: ran-simulator:5678
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000162e
+    grpcport: "5678"
+    latitude: "52.779808"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 175 Cell 1
+- id: 315010-000162f
+  revision: 0
+  address: ran-simulator:5679
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000162f
+    grpcport: "5679"
+    latitude: "52.779808"
+    longitude: "14.144542"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 175 Cell 2
+- id: 315010-0001630
+  revision: 0
+  address: ran-simulator:5680
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001630"
+    grpcport: "5680"
+    latitude: "52.312154"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 176 Cell 0
+- id: 315010-0001631
+  revision: 0
+  address: ran-simulator:5681
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001631"
+    grpcport: "5681"
+    latitude: "52.312154"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 176 Cell 1
+- id: 315010-0001632
+  revision: 0
+  address: ran-simulator:5682
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001632"
+    grpcport: "5682"
+    latitude: "52.312154"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 176 Cell 2
+- id: 315010-0001633
+  revision: 0
+  address: ran-simulator:5683
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001633"
+    grpcport: "5683"
+    latitude: "52.338135"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 177 Cell 0
+- id: 315010-0001634
+  revision: 0
+  address: ran-simulator:5684
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001634"
+    grpcport: "5684"
+    latitude: "52.338135"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 177 Cell 1
+- id: 315010-0001635
+  revision: 0
+  address: ran-simulator:5685
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001635"
+    grpcport: "5685"
+    latitude: "52.338135"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 177 Cell 2
+- id: 315010-0001636
+  revision: 0
+  address: ran-simulator:5686
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001636"
+    grpcport: "5686"
+    latitude: "52.364115"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 178 Cell 0
+- id: 315010-0001637
+  revision: 0
+  address: ran-simulator:5687
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001637"
+    grpcport: "5687"
+    latitude: "52.364115"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 178 Cell 1
+- id: 315010-0001638
+  revision: 0
+  address: ran-simulator:5688
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001638"
+    grpcport: "5688"
+    latitude: "52.364115"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 178 Cell 2
+- id: 315010-0001639
+  revision: 0
+  address: ran-simulator:5689
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001639"
+    grpcport: "5689"
+    latitude: "52.390096"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 179 Cell 0
+- id: 315010-000163a
+  revision: 0
+  address: ran-simulator:5690
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000163a
+    grpcport: "5690"
+    latitude: "52.390096"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 179 Cell 1
+- id: 315010-000163b
+  revision: 0
+  address: ran-simulator:5691
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000163b
+    grpcport: "5691"
+    latitude: "52.390096"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 179 Cell 2
+- id: 315010-000163c
+  revision: 0
+  address: ran-simulator:5692
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000163c
+    grpcport: "5692"
+    latitude: "52.416077"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 180 Cell 0
+- id: 315010-000163d
+  revision: 0
+  address: ran-simulator:5693
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000163d
+    grpcport: "5693"
+    latitude: "52.416077"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 180 Cell 1
+- id: 315010-000163e
+  revision: 0
+  address: ran-simulator:5694
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000163e
+    grpcport: "5694"
+    latitude: "52.416077"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 180 Cell 2
+- id: 315010-000163f
+  revision: 0
+  address: ran-simulator:5695
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000163f
+    grpcport: "5695"
+    latitude: "52.442058"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 181 Cell 0
+- id: 315010-0001640
+  revision: 0
+  address: ran-simulator:5696
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001640"
+    grpcport: "5696"
+    latitude: "52.442058"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 181 Cell 1
+- id: 315010-0001641
+  revision: 0
+  address: ran-simulator:5697
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001641"
+    grpcport: "5697"
+    latitude: "52.442058"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 181 Cell 2
+- id: 315010-0001642
+  revision: 0
+  address: ran-simulator:5698
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001642"
+    grpcport: "5698"
+    latitude: "52.468038"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 182 Cell 0
+- id: 315010-0001643
+  revision: 0
+  address: ran-simulator:5699
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001643"
+    grpcport: "5699"
+    latitude: "52.468038"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 182 Cell 1
+- id: 315010-0001644
+  revision: 0
+  address: ran-simulator:5700
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001644"
+    grpcport: "5700"
+    latitude: "52.468038"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 182 Cell 2
+- id: 315010-0001645
+  revision: 0
+  address: ran-simulator:5701
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001645"
+    grpcport: "5701"
+    latitude: "52.494019"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 183 Cell 0
+- id: 315010-0001646
+  revision: 0
+  address: ran-simulator:5702
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001646"
+    grpcport: "5702"
+    latitude: "52.494019"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 183 Cell 1
+- id: 315010-0001647
+  revision: 0
+  address: ran-simulator:5703
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001647"
+    grpcport: "5703"
+    latitude: "52.494019"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 183 Cell 2
+- id: 315010-0001648
+  revision: 0
+  address: ran-simulator:5704
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001648"
+    grpcport: "5704"
+    latitude: "52.520000"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 184 Cell 0
+- id: 315010-0001649
+  revision: 0
+  address: ran-simulator:5705
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001649"
+    grpcport: "5705"
+    latitude: "52.520000"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 184 Cell 1
+- id: 315010-000164a
+  revision: 0
+  address: ran-simulator:5706
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000164a
+    grpcport: "5706"
+    latitude: "52.520000"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 184 Cell 2
+- id: 315010-000164b
+  revision: 0
+  address: ran-simulator:5707
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000164b
+    grpcport: "5707"
+    latitude: "52.545981"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 185 Cell 0
+- id: 315010-000164c
+  revision: 0
+  address: ran-simulator:5708
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000164c
+    grpcport: "5708"
+    latitude: "52.545981"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 185 Cell 1
+- id: 315010-000164d
+  revision: 0
+  address: ran-simulator:5709
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000164d
+    grpcport: "5709"
+    latitude: "52.545981"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 185 Cell 2
+- id: 315010-000164e
+  revision: 0
+  address: ran-simulator:5710
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000164e
+    grpcport: "5710"
+    latitude: "52.571962"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 186 Cell 0
+- id: 315010-000164f
+  revision: 0
+  address: ran-simulator:5711
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000164f
+    grpcport: "5711"
+    latitude: "52.571962"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 186 Cell 1
+- id: 315010-0001650
+  revision: 0
+  address: ran-simulator:5712
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001650"
+    grpcport: "5712"
+    latitude: "52.571962"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 186 Cell 2
+- id: 315010-0001651
+  revision: 0
+  address: ran-simulator:5713
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001651"
+    grpcport: "5713"
+    latitude: "52.597942"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 187 Cell 0
+- id: 315010-0001652
+  revision: 0
+  address: ran-simulator:5714
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001652"
+    grpcport: "5714"
+    latitude: "52.597942"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 187 Cell 1
+- id: 315010-0001653
+  revision: 0
+  address: ran-simulator:5715
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001653"
+    grpcport: "5715"
+    latitude: "52.597942"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 187 Cell 2
+- id: 315010-0001654
+  revision: 0
+  address: ran-simulator:5716
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001654"
+    grpcport: "5716"
+    latitude: "52.623923"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 188 Cell 0
+- id: 315010-0001655
+  revision: 0
+  address: ran-simulator:5717
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001655"
+    grpcport: "5717"
+    latitude: "52.623923"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 188 Cell 1
+- id: 315010-0001656
+  revision: 0
+  address: ran-simulator:5718
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001656"
+    grpcport: "5718"
+    latitude: "52.623923"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 188 Cell 2
+- id: 315010-0001657
+  revision: 0
+  address: ran-simulator:5719
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001657"
+    grpcport: "5719"
+    latitude: "52.649904"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 189 Cell 0
+- id: 315010-0001658
+  revision: 0
+  address: ran-simulator:5720
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001658"
+    grpcport: "5720"
+    latitude: "52.649904"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 189 Cell 1
+- id: 315010-0001659
+  revision: 0
+  address: ran-simulator:5721
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001659"
+    grpcport: "5721"
+    latitude: "52.649904"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 189 Cell 2
+- id: 315010-000165a
+  revision: 0
+  address: ran-simulator:5722
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000165a
+    grpcport: "5722"
+    latitude: "52.675885"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 190 Cell 0
+- id: 315010-000165b
+  revision: 0
+  address: ran-simulator:5723
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000165b
+    grpcport: "5723"
+    latitude: "52.675885"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 190 Cell 1
+- id: 315010-000165c
+  revision: 0
+  address: ran-simulator:5724
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000165c
+    grpcport: "5724"
+    latitude: "52.675885"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 190 Cell 2
+- id: 315010-000165d
+  revision: 0
+  address: ran-simulator:5725
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000165d
+    grpcport: "5725"
+    latitude: "52.701865"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 191 Cell 0
+- id: 315010-000165e
+  revision: 0
+  address: ran-simulator:5726
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000165e
+    grpcport: "5726"
+    latitude: "52.701865"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 191 Cell 1
+- id: 315010-000165f
+  revision: 0
+  address: ran-simulator:5727
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000165f
+    grpcport: "5727"
+    latitude: "52.701865"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 191 Cell 2
+- id: 315010-0001660
+  revision: 0
+  address: ran-simulator:5728
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001660"
+    grpcport: "5728"
+    latitude: "52.727846"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 192 Cell 0
+- id: 315010-0001661
+  revision: 0
+  address: ran-simulator:5729
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001661"
+    grpcport: "5729"
+    latitude: "52.727846"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 192 Cell 1
+- id: 315010-0001662
+  revision: 0
+  address: ran-simulator:5730
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001662"
+    grpcport: "5730"
+    latitude: "52.727846"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 192 Cell 2
+- id: 315010-0001663
+  revision: 0
+  address: ran-simulator:5731
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001663"
+    grpcport: "5731"
+    latitude: "52.753827"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 193 Cell 0
+- id: 315010-0001664
+  revision: 0
+  address: ran-simulator:5732
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001664"
+    grpcport: "5732"
+    latitude: "52.753827"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 193 Cell 1
+- id: 315010-0001665
+  revision: 0
+  address: ran-simulator:5733
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001665"
+    grpcport: "5733"
+    latitude: "52.753827"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 193 Cell 2
+- id: 315010-0001666
+  revision: 0
+  address: ran-simulator:5734
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001666"
+    grpcport: "5734"
+    latitude: "52.779808"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 194 Cell 0
+- id: 315010-0001667
+  revision: 0
+  address: ran-simulator:5735
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001667"
+    grpcport: "5735"
+    latitude: "52.779808"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 194 Cell 1
+- id: 315010-0001668
+  revision: 0
+  address: ran-simulator:5736
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001668"
+    grpcport: "5736"
+    latitude: "52.779808"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 194 Cell 2
+- id: 315010-0001669
+  revision: 0
+  address: ran-simulator:5737
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001669"
+    grpcport: "5737"
+    latitude: "52.805788"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 195 Cell 0
+- id: 315010-000166a
+  revision: 0
+  address: ran-simulator:5738
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000166a
+    grpcport: "5738"
+    latitude: "52.805788"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 195 Cell 1
+- id: 315010-000166b
+  revision: 0
+  address: ran-simulator:5739
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000166b
+    grpcport: "5739"
+    latitude: "52.805788"
+    longitude: "14.070588"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 195 Cell 2
+- id: 315010-000166c
+  revision: 0
+  address: ran-simulator:5740
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000166c
+    grpcport: "5740"
+    latitude: "52.364115"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 196 Cell 0
+- id: 315010-000166d
+  revision: 0
+  address: ran-simulator:5741
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000166d
+    grpcport: "5741"
+    latitude: "52.364115"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 196 Cell 1
+- id: 315010-000166e
+  revision: 0
+  address: ran-simulator:5742
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000166e
+    grpcport: "5742"
+    latitude: "52.364115"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 196 Cell 2
+- id: 315010-000166f
+  revision: 0
+  address: ran-simulator:5743
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000166f
+    grpcport: "5743"
+    latitude: "52.390096"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 197 Cell 0
+- id: 315010-0001670
+  revision: 0
+  address: ran-simulator:5744
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001670"
+    grpcport: "5744"
+    latitude: "52.390096"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 197 Cell 1
+- id: 315010-0001671
+  revision: 0
+  address: ran-simulator:5745
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001671"
+    grpcport: "5745"
+    latitude: "52.390096"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 197 Cell 2
+- id: 315010-0001672
+  revision: 0
+  address: ran-simulator:5746
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001672"
+    grpcport: "5746"
+    latitude: "52.416077"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 198 Cell 0
+- id: 315010-0001673
+  revision: 0
+  address: ran-simulator:5747
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001673"
+    grpcport: "5747"
+    latitude: "52.416077"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 198 Cell 1
+- id: 315010-0001674
+  revision: 0
+  address: ran-simulator:5748
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001674"
+    grpcport: "5748"
+    latitude: "52.416077"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 198 Cell 2
+- id: 315010-0001675
+  revision: 0
+  address: ran-simulator:5749
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001675"
+    grpcport: "5749"
+    latitude: "52.442058"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 199 Cell 0
+- id: 315010-0001676
+  revision: 0
+  address: ran-simulator:5750
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001676"
+    grpcport: "5750"
+    latitude: "52.442058"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 199 Cell 1
+- id: 315010-0001677
+  revision: 0
+  address: ran-simulator:5751
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001677"
+    grpcport: "5751"
+    latitude: "52.442058"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 199 Cell 2
+- id: 315010-0001678
+  revision: 0
+  address: ran-simulator:5752
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001678"
+    grpcport: "5752"
+    latitude: "52.468038"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 200 Cell 0
+- id: 315010-0001679
+  revision: 0
+  address: ran-simulator:5753
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001679"
+    grpcport: "5753"
+    latitude: "52.468038"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 200 Cell 1
+- id: 315010-000167a
+  revision: 0
+  address: ran-simulator:5754
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000167a
+    grpcport: "5754"
+    latitude: "52.468038"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 200 Cell 2
+- id: 315010-000167b
+  revision: 0
+  address: ran-simulator:5755
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000167b
+    grpcport: "5755"
+    latitude: "52.494019"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 201 Cell 0
+- id: 315010-000167c
+  revision: 0
+  address: ran-simulator:5756
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000167c
+    grpcport: "5756"
+    latitude: "52.494019"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 201 Cell 1
+- id: 315010-000167d
+  revision: 0
+  address: ran-simulator:5757
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000167d
+    grpcport: "5757"
+    latitude: "52.494019"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 201 Cell 2
+- id: 315010-000167e
+  revision: 0
+  address: ran-simulator:5758
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000167e
+    grpcport: "5758"
+    latitude: "52.520000"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 202 Cell 0
+- id: 315010-000167f
+  revision: 0
+  address: ran-simulator:5759
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000167f
+    grpcport: "5759"
+    latitude: "52.520000"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 202 Cell 1
+- id: 315010-0001680
+  revision: 0
+  address: ran-simulator:5760
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001680"
+    grpcport: "5760"
+    latitude: "52.520000"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 202 Cell 2
+- id: 315010-0001681
+  revision: 0
+  address: ran-simulator:5761
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001681"
+    grpcport: "5761"
+    latitude: "52.545981"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 203 Cell 0
+- id: 315010-0001682
+  revision: 0
+  address: ran-simulator:5762
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001682"
+    grpcport: "5762"
+    latitude: "52.545981"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 203 Cell 1
+- id: 315010-0001683
+  revision: 0
+  address: ran-simulator:5763
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001683"
+    grpcport: "5763"
+    latitude: "52.545981"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 203 Cell 2
+- id: 315010-0001684
+  revision: 0
+  address: ran-simulator:5764
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001684"
+    grpcport: "5764"
+    latitude: "52.571962"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 204 Cell 0
+- id: 315010-0001685
+  revision: 0
+  address: ran-simulator:5765
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001685"
+    grpcport: "5765"
+    latitude: "52.571962"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 204 Cell 1
+- id: 315010-0001686
+  revision: 0
+  address: ran-simulator:5766
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001686"
+    grpcport: "5766"
+    latitude: "52.571962"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 204 Cell 2
+- id: 315010-0001687
+  revision: 0
+  address: ran-simulator:5767
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001687"
+    grpcport: "5767"
+    latitude: "52.597942"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 205 Cell 0
+- id: 315010-0001688
+  revision: 0
+  address: ran-simulator:5768
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001688"
+    grpcport: "5768"
+    latitude: "52.597942"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 205 Cell 1
+- id: 315010-0001689
+  revision: 0
+  address: ran-simulator:5769
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001689"
+    grpcport: "5769"
+    latitude: "52.597942"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 205 Cell 2
+- id: 315010-000168a
+  revision: 0
+  address: ran-simulator:5770
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000168a
+    grpcport: "5770"
+    latitude: "52.623923"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 206 Cell 0
+- id: 315010-000168b
+  revision: 0
+  address: ran-simulator:5771
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000168b
+    grpcport: "5771"
+    latitude: "52.623923"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 206 Cell 1
+- id: 315010-000168c
+  revision: 0
+  address: ran-simulator:5772
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000168c
+    grpcport: "5772"
+    latitude: "52.623923"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 206 Cell 2
+- id: 315010-000168d
+  revision: 0
+  address: ran-simulator:5773
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000168d
+    grpcport: "5773"
+    latitude: "52.649904"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 207 Cell 0
+- id: 315010-000168e
+  revision: 0
+  address: ran-simulator:5774
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000168e
+    grpcport: "5774"
+    latitude: "52.649904"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 207 Cell 1
+- id: 315010-000168f
+  revision: 0
+  address: ran-simulator:5775
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000168f
+    grpcport: "5775"
+    latitude: "52.649904"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 207 Cell 2
+- id: 315010-0001690
+  revision: 0
+  address: ran-simulator:5776
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001690"
+    grpcport: "5776"
+    latitude: "52.675885"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 208 Cell 0
+- id: 315010-0001691
+  revision: 0
+  address: ran-simulator:5777
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001691"
+    grpcport: "5777"
+    latitude: "52.675885"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 208 Cell 1
+- id: 315010-0001692
+  revision: 0
+  address: ran-simulator:5778
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001692"
+    grpcport: "5778"
+    latitude: "52.675885"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 208 Cell 2
+- id: 315010-0001693
+  revision: 0
+  address: ran-simulator:5779
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001693"
+    grpcport: "5779"
+    latitude: "52.701865"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 209 Cell 0
+- id: 315010-0001694
+  revision: 0
+  address: ran-simulator:5780
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001694"
+    grpcport: "5780"
+    latitude: "52.701865"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 209 Cell 1
+- id: 315010-0001695
+  revision: 0
+  address: ran-simulator:5781
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001695"
+    grpcport: "5781"
+    latitude: "52.701865"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 209 Cell 2
+- id: 315010-0001696
+  revision: 0
+  address: ran-simulator:5782
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001696"
+    grpcport: "5782"
+    latitude: "52.727846"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 210 Cell 0
+- id: 315010-0001697
+  revision: 0
+  address: ran-simulator:5783
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001697"
+    grpcport: "5783"
+    latitude: "52.727846"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 210 Cell 1
+- id: 315010-0001698
+  revision: 0
+  address: ran-simulator:5784
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001698"
+    grpcport: "5784"
+    latitude: "52.727846"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 210 Cell 2
+- id: 315010-0001699
+  revision: 0
+  address: ran-simulator:5785
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001699"
+    grpcport: "5785"
+    latitude: "52.753827"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 211 Cell 0
+- id: 315010-000169a
+  revision: 0
+  address: ran-simulator:5786
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000169a
+    grpcport: "5786"
+    latitude: "52.753827"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 211 Cell 1
+- id: 315010-000169b
+  revision: 0
+  address: ran-simulator:5787
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000169b
+    grpcport: "5787"
+    latitude: "52.753827"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 211 Cell 2
+- id: 315010-000169c
+  revision: 0
+  address: ran-simulator:5788
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000169c
+    grpcport: "5788"
+    latitude: "52.779808"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 212 Cell 0
+- id: 315010-000169d
+  revision: 0
+  address: ran-simulator:5789
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000169d
+    grpcport: "5789"
+    latitude: "52.779808"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 212 Cell 1
+- id: 315010-000169e
+  revision: 0
+  address: ran-simulator:5790
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000169e
+    grpcport: "5790"
+    latitude: "52.779808"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 212 Cell 2
+- id: 315010-000169f
+  revision: 0
+  address: ran-simulator:5791
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000169f
+    grpcport: "5791"
+    latitude: "52.805788"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 213 Cell 0
+- id: 315010-00016a0
+  revision: 0
+  address: ran-simulator:5792
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016a0
+    grpcport: "5792"
+    latitude: "52.805788"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 213 Cell 1
+- id: 315010-00016a1
+  revision: 0
+  address: ran-simulator:5793
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016a1
+    grpcport: "5793"
+    latitude: "52.805788"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 213 Cell 2
+- id: 315010-00016a2
+  revision: 0
+  address: ran-simulator:5794
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016a2
+    grpcport: "5794"
+    latitude: "52.831769"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 214 Cell 0
+- id: 315010-00016a3
+  revision: 0
+  address: ran-simulator:5795
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016a3
+    grpcport: "5795"
+    latitude: "52.831769"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 214 Cell 1
+- id: 315010-00016a4
+  revision: 0
+  address: ran-simulator:5796
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016a4
+    grpcport: "5796"
+    latitude: "52.831769"
+    longitude: "13.996634"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 214 Cell 2
+- id: 315010-00016a5
+  revision: 0
+  address: ran-simulator:5797
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016a5
+    grpcport: "5797"
+    latitude: "52.416077"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 215 Cell 0
+- id: 315010-00016a6
+  revision: 0
+  address: ran-simulator:5798
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016a6
+    grpcport: "5798"
+    latitude: "52.416077"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 215 Cell 1
+- id: 315010-00016a7
+  revision: 0
+  address: ran-simulator:5799
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016a7
+    grpcport: "5799"
+    latitude: "52.416077"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 215 Cell 2
+- id: 315010-00016a8
+  revision: 0
+  address: ran-simulator:5800
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016a8
+    grpcport: "5800"
+    latitude: "52.442058"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 216 Cell 0
+- id: 315010-00016a9
+  revision: 0
+  address: ran-simulator:5801
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016a9
+    grpcport: "5801"
+    latitude: "52.442058"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 216 Cell 1
+- id: 315010-00016aa
+  revision: 0
+  address: ran-simulator:5802
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016aa
+    grpcport: "5802"
+    latitude: "52.442058"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 216 Cell 2
+- id: 315010-00016ab
+  revision: 0
+  address: ran-simulator:5803
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016ab
+    grpcport: "5803"
+    latitude: "52.468038"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 217 Cell 0
+- id: 315010-00016ac
+  revision: 0
+  address: ran-simulator:5804
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016ac
+    grpcport: "5804"
+    latitude: "52.468038"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 217 Cell 1
+- id: 315010-00016ad
+  revision: 0
+  address: ran-simulator:5805
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016ad
+    grpcport: "5805"
+    latitude: "52.468038"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 217 Cell 2
+- id: 315010-00016ae
+  revision: 0
+  address: ran-simulator:5806
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016ae
+    grpcport: "5806"
+    latitude: "52.494019"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 218 Cell 0
+- id: 315010-00016af
+  revision: 0
+  address: ran-simulator:5807
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016af
+    grpcport: "5807"
+    latitude: "52.494019"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 218 Cell 1
+- id: 315010-00016b0
+  revision: 0
+  address: ran-simulator:5808
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016b0
+    grpcport: "5808"
+    latitude: "52.494019"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 218 Cell 2
+- id: 315010-00016b1
+  revision: 0
+  address: ran-simulator:5809
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016b1
+    grpcport: "5809"
+    latitude: "52.520000"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 219 Cell 0
+- id: 315010-00016b2
+  revision: 0
+  address: ran-simulator:5810
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016b2
+    grpcport: "5810"
+    latitude: "52.520000"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 219 Cell 1
+- id: 315010-00016b3
+  revision: 0
+  address: ran-simulator:5811
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016b3
+    grpcport: "5811"
+    latitude: "52.520000"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 219 Cell 2
+- id: 315010-00016b4
+  revision: 0
+  address: ran-simulator:5812
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016b4
+    grpcport: "5812"
+    latitude: "52.545981"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 220 Cell 0
+- id: 315010-00016b5
+  revision: 0
+  address: ran-simulator:5813
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016b5
+    grpcport: "5813"
+    latitude: "52.545981"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 220 Cell 1
+- id: 315010-00016b6
+  revision: 0
+  address: ran-simulator:5814
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016b6
+    grpcport: "5814"
+    latitude: "52.545981"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 220 Cell 2
+- id: 315010-00016b7
+  revision: 0
+  address: ran-simulator:5815
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016b7
+    grpcport: "5815"
+    latitude: "52.571962"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 221 Cell 0
+- id: 315010-00016b8
+  revision: 0
+  address: ran-simulator:5816
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016b8
+    grpcport: "5816"
+    latitude: "52.571962"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 221 Cell 1
+- id: 315010-00016b9
+  revision: 0
+  address: ran-simulator:5817
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016b9
+    grpcport: "5817"
+    latitude: "52.571962"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 221 Cell 2
+- id: 315010-00016ba
+  revision: 0
+  address: ran-simulator:5818
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016ba
+    grpcport: "5818"
+    latitude: "52.597942"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 222 Cell 0
+- id: 315010-00016bb
+  revision: 0
+  address: ran-simulator:5819
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016bb
+    grpcport: "5819"
+    latitude: "52.597942"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 222 Cell 1
+- id: 315010-00016bc
+  revision: 0
+  address: ran-simulator:5820
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016bc
+    grpcport: "5820"
+    latitude: "52.597942"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 222 Cell 2
+- id: 315010-00016bd
+  revision: 0
+  address: ran-simulator:5821
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016bd
+    grpcport: "5821"
+    latitude: "52.623923"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 223 Cell 0
+- id: 315010-00016be
+  revision: 0
+  address: ran-simulator:5822
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016be
+    grpcport: "5822"
+    latitude: "52.623923"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 223 Cell 1
+- id: 315010-00016bf
+  revision: 0
+  address: ran-simulator:5823
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016bf
+    grpcport: "5823"
+    latitude: "52.623923"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 223 Cell 2
+- id: 315010-00016c0
+  revision: 0
+  address: ran-simulator:5824
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016c0
+    grpcport: "5824"
+    latitude: "52.649904"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 224 Cell 0
+- id: 315010-00016c1
+  revision: 0
+  address: ran-simulator:5825
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016c1
+    grpcport: "5825"
+    latitude: "52.649904"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 224 Cell 1
+- id: 315010-00016c2
+  revision: 0
+  address: ran-simulator:5826
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016c2
+    grpcport: "5826"
+    latitude: "52.649904"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 224 Cell 2
+- id: 315010-00016c3
+  revision: 0
+  address: ran-simulator:5827
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016c3
+    grpcport: "5827"
+    latitude: "52.675885"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 225 Cell 0
+- id: 315010-00016c4
+  revision: 0
+  address: ran-simulator:5828
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016c4
+    grpcport: "5828"
+    latitude: "52.675885"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 225 Cell 1
+- id: 315010-00016c5
+  revision: 0
+  address: ran-simulator:5829
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016c5
+    grpcport: "5829"
+    latitude: "52.675885"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 225 Cell 2
+- id: 315010-00016c6
+  revision: 0
+  address: ran-simulator:5830
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016c6
+    grpcport: "5830"
+    latitude: "52.701865"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 226 Cell 0
+- id: 315010-00016c7
+  revision: 0
+  address: ran-simulator:5831
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016c7
+    grpcport: "5831"
+    latitude: "52.701865"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 226 Cell 1
+- id: 315010-00016c8
+  revision: 0
+  address: ran-simulator:5832
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016c8
+    grpcport: "5832"
+    latitude: "52.701865"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 226 Cell 2
+- id: 315010-00016c9
+  revision: 0
+  address: ran-simulator:5833
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016c9
+    grpcport: "5833"
+    latitude: "52.727846"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 227 Cell 0
+- id: 315010-00016ca
+  revision: 0
+  address: ran-simulator:5834
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016ca
+    grpcport: "5834"
+    latitude: "52.727846"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 227 Cell 1
+- id: 315010-00016cb
+  revision: 0
+  address: ran-simulator:5835
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016cb
+    grpcport: "5835"
+    latitude: "52.727846"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 227 Cell 2
+- id: 315010-00016cc
+  revision: 0
+  address: ran-simulator:5836
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016cc
+    grpcport: "5836"
+    latitude: "52.753827"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 228 Cell 0
+- id: 315010-00016cd
+  revision: 0
+  address: ran-simulator:5837
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016cd
+    grpcport: "5837"
+    latitude: "52.753827"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 228 Cell 1
+- id: 315010-00016ce
+  revision: 0
+  address: ran-simulator:5838
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016ce
+    grpcport: "5838"
+    latitude: "52.753827"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 228 Cell 2
+- id: 315010-00016cf
+  revision: 0
+  address: ran-simulator:5839
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016cf
+    grpcport: "5839"
+    latitude: "52.779808"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 229 Cell 0
+- id: 315010-00016d0
+  revision: 0
+  address: ran-simulator:5840
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016d0
+    grpcport: "5840"
+    latitude: "52.779808"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 229 Cell 1
+- id: 315010-00016d1
+  revision: 0
+  address: ran-simulator:5841
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016d1
+    grpcport: "5841"
+    latitude: "52.779808"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 229 Cell 2
+- id: 315010-00016d2
+  revision: 0
+  address: ran-simulator:5842
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016d2
+    grpcport: "5842"
+    latitude: "52.805788"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 230 Cell 0
+- id: 315010-00016d3
+  revision: 0
+  address: ran-simulator:5843
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016d3
+    grpcport: "5843"
+    latitude: "52.805788"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 230 Cell 1
+- id: 315010-00016d4
+  revision: 0
+  address: ran-simulator:5844
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016d4
+    grpcport: "5844"
+    latitude: "52.805788"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 230 Cell 2
+- id: 315010-00016d5
+  revision: 0
+  address: ran-simulator:5845
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016d5
+    grpcport: "5845"
+    latitude: "52.831769"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 231 Cell 0
+- id: 315010-00016d6
+  revision: 0
+  address: ran-simulator:5846
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016d6
+    grpcport: "5846"
+    latitude: "52.831769"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 231 Cell 1
+- id: 315010-00016d7
+  revision: 0
+  address: ran-simulator:5847
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016d7
+    grpcport: "5847"
+    latitude: "52.831769"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 231 Cell 2
+- id: 315010-00016d8
+  revision: 0
+  address: ran-simulator:5848
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016d8
+    grpcport: "5848"
+    latitude: "52.857750"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 232 Cell 0
+- id: 315010-00016d9
+  revision: 0
+  address: ran-simulator:5849
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016d9
+    grpcport: "5849"
+    latitude: "52.857750"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 232 Cell 1
+- id: 315010-00016da
+  revision: 0
+  address: ran-simulator:5850
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016da
+    grpcport: "5850"
+    latitude: "52.857750"
+    longitude: "13.922680"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 232 Cell 2
+- id: 315010-00016db
+  revision: 0
+  address: ran-simulator:5851
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016db
+    grpcport: "5851"
+    latitude: "52.468038"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 233 Cell 0
+- id: 315010-00016dc
+  revision: 0
+  address: ran-simulator:5852
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016dc
+    grpcport: "5852"
+    latitude: "52.468038"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 233 Cell 1
+- id: 315010-00016dd
+  revision: 0
+  address: ran-simulator:5853
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016dd
+    grpcport: "5853"
+    latitude: "52.468038"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 233 Cell 2
+- id: 315010-00016de
+  revision: 0
+  address: ran-simulator:5854
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016de
+    grpcport: "5854"
+    latitude: "52.494019"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 234 Cell 0
+- id: 315010-00016df
+  revision: 0
+  address: ran-simulator:5855
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016df
+    grpcport: "5855"
+    latitude: "52.494019"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 234 Cell 1
+- id: 315010-00016e0
+  revision: 0
+  address: ran-simulator:5856
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00016e0"
+    grpcport: "5856"
+    latitude: "52.494019"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 234 Cell 2
+- id: 315010-00016e1
+  revision: 0
+  address: ran-simulator:5857
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00016e1"
+    grpcport: "5857"
+    latitude: "52.520000"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 235 Cell 0
+- id: 315010-00016e2
+  revision: 0
+  address: ran-simulator:5858
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00016e2"
+    grpcport: "5858"
+    latitude: "52.520000"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 235 Cell 1
+- id: 315010-00016e3
+  revision: 0
+  address: ran-simulator:5859
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00016e3"
+    grpcport: "5859"
+    latitude: "52.520000"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 235 Cell 2
+- id: 315010-00016e4
+  revision: 0
+  address: ran-simulator:5860
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00016e4"
+    grpcport: "5860"
+    latitude: "52.545981"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 236 Cell 0
+- id: 315010-00016e5
+  revision: 0
+  address: ran-simulator:5861
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00016e5"
+    grpcport: "5861"
+    latitude: "52.545981"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 236 Cell 1
+- id: 315010-00016e6
+  revision: 0
+  address: ran-simulator:5862
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00016e6"
+    grpcport: "5862"
+    latitude: "52.545981"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 236 Cell 2
+- id: 315010-00016e7
+  revision: 0
+  address: ran-simulator:5863
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00016e7"
+    grpcport: "5863"
+    latitude: "52.571962"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 237 Cell 0
+- id: 315010-00016e8
+  revision: 0
+  address: ran-simulator:5864
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00016e8"
+    grpcport: "5864"
+    latitude: "52.571962"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 237 Cell 1
+- id: 315010-00016e9
+  revision: 0
+  address: ran-simulator:5865
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00016e9"
+    grpcport: "5865"
+    latitude: "52.571962"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 237 Cell 2
+- id: 315010-00016ea
+  revision: 0
+  address: ran-simulator:5866
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016ea
+    grpcport: "5866"
+    latitude: "52.597942"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 238 Cell 0
+- id: 315010-00016eb
+  revision: 0
+  address: ran-simulator:5867
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016eb
+    grpcport: "5867"
+    latitude: "52.597942"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 238 Cell 1
+- id: 315010-00016ec
+  revision: 0
+  address: ran-simulator:5868
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016ec
+    grpcport: "5868"
+    latitude: "52.597942"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 238 Cell 2
+- id: 315010-00016ed
+  revision: 0
+  address: ran-simulator:5869
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016ed
+    grpcport: "5869"
+    latitude: "52.623923"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 239 Cell 0
+- id: 315010-00016ee
+  revision: 0
+  address: ran-simulator:5870
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016ee
+    grpcport: "5870"
+    latitude: "52.623923"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 239 Cell 1
+- id: 315010-00016ef
+  revision: 0
+  address: ran-simulator:5871
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016ef
+    grpcport: "5871"
+    latitude: "52.623923"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 239 Cell 2
+- id: 315010-00016f0
+  revision: 0
+  address: ran-simulator:5872
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016f0
+    grpcport: "5872"
+    latitude: "52.649904"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 240 Cell 0
+- id: 315010-00016f1
+  revision: 0
+  address: ran-simulator:5873
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016f1
+    grpcport: "5873"
+    latitude: "52.649904"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 240 Cell 1
+- id: 315010-00016f2
+  revision: 0
+  address: ran-simulator:5874
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016f2
+    grpcport: "5874"
+    latitude: "52.649904"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 240 Cell 2
+- id: 315010-00016f3
+  revision: 0
+  address: ran-simulator:5875
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016f3
+    grpcport: "5875"
+    latitude: "52.675885"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 241 Cell 0
+- id: 315010-00016f4
+  revision: 0
+  address: ran-simulator:5876
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016f4
+    grpcport: "5876"
+    latitude: "52.675885"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 241 Cell 1
+- id: 315010-00016f5
+  revision: 0
+  address: ran-simulator:5877
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016f5
+    grpcport: "5877"
+    latitude: "52.675885"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 241 Cell 2
+- id: 315010-00016f6
+  revision: 0
+  address: ran-simulator:5878
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016f6
+    grpcport: "5878"
+    latitude: "52.701865"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 242 Cell 0
+- id: 315010-00016f7
+  revision: 0
+  address: ran-simulator:5879
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016f7
+    grpcport: "5879"
+    latitude: "52.701865"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 242 Cell 1
+- id: 315010-00016f8
+  revision: 0
+  address: ran-simulator:5880
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016f8
+    grpcport: "5880"
+    latitude: "52.701865"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 242 Cell 2
+- id: 315010-00016f9
+  revision: 0
+  address: ran-simulator:5881
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016f9
+    grpcport: "5881"
+    latitude: "52.727846"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 243 Cell 0
+- id: 315010-00016fa
+  revision: 0
+  address: ran-simulator:5882
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016fa
+    grpcport: "5882"
+    latitude: "52.727846"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 243 Cell 1
+- id: 315010-00016fb
+  revision: 0
+  address: ran-simulator:5883
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016fb
+    grpcport: "5883"
+    latitude: "52.727846"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 243 Cell 2
+- id: 315010-00016fc
+  revision: 0
+  address: ran-simulator:5884
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016fc
+    grpcport: "5884"
+    latitude: "52.753827"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 244 Cell 0
+- id: 315010-00016fd
+  revision: 0
+  address: ran-simulator:5885
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00016fd
+    grpcport: "5885"
+    latitude: "52.753827"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 244 Cell 1
+- id: 315010-00016fe
+  revision: 0
+  address: ran-simulator:5886
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00016fe
+    grpcport: "5886"
+    latitude: "52.753827"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 244 Cell 2
+- id: 315010-00016ff
+  revision: 0
+  address: ran-simulator:5887
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00016ff
+    grpcport: "5887"
+    latitude: "52.779808"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 245 Cell 0
+- id: 315010-0001700
+  revision: 0
+  address: ran-simulator:5888
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001700"
+    grpcport: "5888"
+    latitude: "52.779808"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 245 Cell 1
+- id: 315010-0001701
+  revision: 0
+  address: ran-simulator:5889
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001701"
+    grpcport: "5889"
+    latitude: "52.779808"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 245 Cell 2
+- id: 315010-0001702
+  revision: 0
+  address: ran-simulator:5890
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001702"
+    grpcport: "5890"
+    latitude: "52.805788"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 246 Cell 0
+- id: 315010-0001703
+  revision: 0
+  address: ran-simulator:5891
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001703"
+    grpcport: "5891"
+    latitude: "52.805788"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 246 Cell 1
+- id: 315010-0001704
+  revision: 0
+  address: ran-simulator:5892
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001704"
+    grpcport: "5892"
+    latitude: "52.805788"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 246 Cell 2
+- id: 315010-0001705
+  revision: 0
+  address: ran-simulator:5893
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001705"
+    grpcport: "5893"
+    latitude: "52.831769"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 247 Cell 0
+- id: 315010-0001706
+  revision: 0
+  address: ran-simulator:5894
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001706"
+    grpcport: "5894"
+    latitude: "52.831769"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 247 Cell 1
+- id: 315010-0001707
+  revision: 0
+  address: ran-simulator:5895
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001707"
+    grpcport: "5895"
+    latitude: "52.831769"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 247 Cell 2
+- id: 315010-0001708
+  revision: 0
+  address: ran-simulator:5896
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001708"
+    grpcport: "5896"
+    latitude: "52.857750"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 248 Cell 0
+- id: 315010-0001709
+  revision: 0
+  address: ran-simulator:5897
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001709"
+    grpcport: "5897"
+    latitude: "52.857750"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 248 Cell 1
+- id: 315010-000170a
+  revision: 0
+  address: ran-simulator:5898
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000170a
+    grpcport: "5898"
+    latitude: "52.857750"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 248 Cell 2
+- id: 315010-000170b
+  revision: 0
+  address: ran-simulator:5899
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000170b
+    grpcport: "5899"
+    latitude: "52.883731"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 249 Cell 0
+- id: 315010-000170c
+  revision: 0
+  address: ran-simulator:5900
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000170c
+    grpcport: "5900"
+    latitude: "52.883731"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 249 Cell 1
+- id: 315010-000170d
+  revision: 0
+  address: ran-simulator:5901
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000170d
+    grpcport: "5901"
+    latitude: "52.883731"
+    longitude: "13.848725"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 249 Cell 2
+- id: 315010-000170e
+  revision: 0
+  address: ran-simulator:5902
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000170e
+    grpcport: "5902"
+    latitude: "52.520000"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 250 Cell 0
+- id: 315010-000170f
+  revision: 0
+  address: ran-simulator:5903
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000170f
+    grpcport: "5903"
+    latitude: "52.520000"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 250 Cell 1
+- id: 315010-0001710
+  revision: 0
+  address: ran-simulator:5904
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001710"
+    grpcport: "5904"
+    latitude: "52.520000"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 250 Cell 2
+- id: 315010-0001711
+  revision: 0
+  address: ran-simulator:5905
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001711"
+    grpcport: "5905"
+    latitude: "52.545981"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 251 Cell 0
+- id: 315010-0001712
+  revision: 0
+  address: ran-simulator:5906
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001712"
+    grpcport: "5906"
+    latitude: "52.545981"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 251 Cell 1
+- id: 315010-0001713
+  revision: 0
+  address: ran-simulator:5907
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001713"
+    grpcport: "5907"
+    latitude: "52.545981"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 251 Cell 2
+- id: 315010-0001714
+  revision: 0
+  address: ran-simulator:5908
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001714"
+    grpcport: "5908"
+    latitude: "52.571962"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 252 Cell 0
+- id: 315010-0001715
+  revision: 0
+  address: ran-simulator:5909
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001715"
+    grpcport: "5909"
+    latitude: "52.571962"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 252 Cell 1
+- id: 315010-0001716
+  revision: 0
+  address: ran-simulator:5910
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001716"
+    grpcport: "5910"
+    latitude: "52.571962"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 252 Cell 2
+- id: 315010-0001717
+  revision: 0
+  address: ran-simulator:5911
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001717"
+    grpcport: "5911"
+    latitude: "52.597942"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 253 Cell 0
+- id: 315010-0001718
+  revision: 0
+  address: ran-simulator:5912
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001718"
+    grpcport: "5912"
+    latitude: "52.597942"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 253 Cell 1
+- id: 315010-0001719
+  revision: 0
+  address: ran-simulator:5913
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001719"
+    grpcport: "5913"
+    latitude: "52.597942"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 253 Cell 2
+- id: 315010-000171a
+  revision: 0
+  address: ran-simulator:5914
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000171a
+    grpcport: "5914"
+    latitude: "52.623923"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 254 Cell 0
+- id: 315010-000171b
+  revision: 0
+  address: ran-simulator:5915
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000171b
+    grpcport: "5915"
+    latitude: "52.623923"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 254 Cell 1
+- id: 315010-000171c
+  revision: 0
+  address: ran-simulator:5916
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000171c
+    grpcport: "5916"
+    latitude: "52.623923"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 254 Cell 2
+- id: 315010-000171d
+  revision: 0
+  address: ran-simulator:5917
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000171d
+    grpcport: "5917"
+    latitude: "52.649904"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 255 Cell 0
+- id: 315010-000171e
+  revision: 0
+  address: ran-simulator:5918
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000171e
+    grpcport: "5918"
+    latitude: "52.649904"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 255 Cell 1
+- id: 315010-000171f
+  revision: 0
+  address: ran-simulator:5919
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000171f
+    grpcport: "5919"
+    latitude: "52.649904"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 255 Cell 2
+- id: 315010-0001720
+  revision: 0
+  address: ran-simulator:5920
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001720"
+    grpcport: "5920"
+    latitude: "52.675885"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 256 Cell 0
+- id: 315010-0001721
+  revision: 0
+  address: ran-simulator:5921
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001721"
+    grpcport: "5921"
+    latitude: "52.675885"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 256 Cell 1
+- id: 315010-0001722
+  revision: 0
+  address: ran-simulator:5922
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001722"
+    grpcport: "5922"
+    latitude: "52.675885"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 256 Cell 2
+- id: 315010-0001723
+  revision: 0
+  address: ran-simulator:5923
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001723"
+    grpcport: "5923"
+    latitude: "52.701865"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 257 Cell 0
+- id: 315010-0001724
+  revision: 0
+  address: ran-simulator:5924
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001724"
+    grpcport: "5924"
+    latitude: "52.701865"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 257 Cell 1
+- id: 315010-0001725
+  revision: 0
+  address: ran-simulator:5925
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001725"
+    grpcport: "5925"
+    latitude: "52.701865"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 257 Cell 2
+- id: 315010-0001726
+  revision: 0
+  address: ran-simulator:5926
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001726"
+    grpcport: "5926"
+    latitude: "52.727846"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 258 Cell 0
+- id: 315010-0001727
+  revision: 0
+  address: ran-simulator:5927
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001727"
+    grpcport: "5927"
+    latitude: "52.727846"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 258 Cell 1
+- id: 315010-0001728
+  revision: 0
+  address: ran-simulator:5928
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001728"
+    grpcport: "5928"
+    latitude: "52.727846"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 258 Cell 2
+- id: 315010-0001729
+  revision: 0
+  address: ran-simulator:5929
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001729"
+    grpcport: "5929"
+    latitude: "52.753827"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 259 Cell 0
+- id: 315010-000172a
+  revision: 0
+  address: ran-simulator:5930
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000172a
+    grpcport: "5930"
+    latitude: "52.753827"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 259 Cell 1
+- id: 315010-000172b
+  revision: 0
+  address: ran-simulator:5931
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000172b
+    grpcport: "5931"
+    latitude: "52.753827"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 259 Cell 2
+- id: 315010-000172c
+  revision: 0
+  address: ran-simulator:5932
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000172c
+    grpcport: "5932"
+    latitude: "52.779808"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 260 Cell 0
+- id: 315010-000172d
+  revision: 0
+  address: ran-simulator:5933
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000172d
+    grpcport: "5933"
+    latitude: "52.779808"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 260 Cell 1
+- id: 315010-000172e
+  revision: 0
+  address: ran-simulator:5934
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000172e
+    grpcport: "5934"
+    latitude: "52.779808"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 260 Cell 2
+- id: 315010-000172f
+  revision: 0
+  address: ran-simulator:5935
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000172f
+    grpcport: "5935"
+    latitude: "52.805788"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 261 Cell 0
+- id: 315010-0001730
+  revision: 0
+  address: ran-simulator:5936
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001730"
+    grpcport: "5936"
+    latitude: "52.805788"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 261 Cell 1
+- id: 315010-0001731
+  revision: 0
+  address: ran-simulator:5937
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001731"
+    grpcport: "5937"
+    latitude: "52.805788"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 261 Cell 2
+- id: 315010-0001732
+  revision: 0
+  address: ran-simulator:5938
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001732"
+    grpcport: "5938"
+    latitude: "52.831769"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 262 Cell 0
+- id: 315010-0001733
+  revision: 0
+  address: ran-simulator:5939
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001733"
+    grpcport: "5939"
+    latitude: "52.831769"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 262 Cell 1
+- id: 315010-0001734
+  revision: 0
+  address: ran-simulator:5940
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001734"
+    grpcport: "5940"
+    latitude: "52.831769"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 262 Cell 2
+- id: 315010-0001735
+  revision: 0
+  address: ran-simulator:5941
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001735"
+    grpcport: "5941"
+    latitude: "52.857750"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 263 Cell 0
+- id: 315010-0001736
+  revision: 0
+  address: ran-simulator:5942
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001736"
+    grpcport: "5942"
+    latitude: "52.857750"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 263 Cell 1
+- id: 315010-0001737
+  revision: 0
+  address: ran-simulator:5943
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001737"
+    grpcport: "5943"
+    latitude: "52.857750"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 263 Cell 2
+- id: 315010-0001738
+  revision: 0
+  address: ran-simulator:5944
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001738"
+    grpcport: "5944"
+    latitude: "52.883731"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 264 Cell 0
+- id: 315010-0001739
+  revision: 0
+  address: ran-simulator:5945
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001739"
+    grpcport: "5945"
+    latitude: "52.883731"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 264 Cell 1
+- id: 315010-000173a
+  revision: 0
+  address: ran-simulator:5946
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000173a
+    grpcport: "5946"
+    latitude: "52.883731"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 264 Cell 2
+- id: 315010-000173b
+  revision: 0
+  address: ran-simulator:5947
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000173b
+    grpcport: "5947"
+    latitude: "52.909711"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 265 Cell 0
+- id: 315010-000173c
+  revision: 0
+  address: ran-simulator:5948
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000173c
+    grpcport: "5948"
+    latitude: "52.909711"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 265 Cell 1
+- id: 315010-000173d
+  revision: 0
+  address: ran-simulator:5949
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000173d
+    grpcport: "5949"
+    latitude: "52.909711"
+    longitude: "13.774771"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 265 Cell 2
+- id: 315010-000173e
+  revision: 0
+  address: ran-simulator:5950
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000173e
+    grpcport: "5950"
+    latitude: "52.571962"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 266 Cell 0
+- id: 315010-000173f
+  revision: 0
+  address: ran-simulator:5951
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000173f
+    grpcport: "5951"
+    latitude: "52.571962"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 266 Cell 1
+- id: 315010-0001740
+  revision: 0
+  address: ran-simulator:5952
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001740"
+    grpcport: "5952"
+    latitude: "52.571962"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 266 Cell 2
+- id: 315010-0001741
+  revision: 0
+  address: ran-simulator:5953
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001741"
+    grpcport: "5953"
+    latitude: "52.597942"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 267 Cell 0
+- id: 315010-0001742
+  revision: 0
+  address: ran-simulator:5954
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001742"
+    grpcport: "5954"
+    latitude: "52.597942"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 267 Cell 1
+- id: 315010-0001743
+  revision: 0
+  address: ran-simulator:5955
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001743"
+    grpcport: "5955"
+    latitude: "52.597942"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 267 Cell 2
+- id: 315010-0001744
+  revision: 0
+  address: ran-simulator:5956
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001744"
+    grpcport: "5956"
+    latitude: "52.623923"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 268 Cell 0
+- id: 315010-0001745
+  revision: 0
+  address: ran-simulator:5957
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001745"
+    grpcport: "5957"
+    latitude: "52.623923"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 268 Cell 1
+- id: 315010-0001746
+  revision: 0
+  address: ran-simulator:5958
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001746"
+    grpcport: "5958"
+    latitude: "52.623923"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 268 Cell 2
+- id: 315010-0001747
+  revision: 0
+  address: ran-simulator:5959
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001747"
+    grpcport: "5959"
+    latitude: "52.649904"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 269 Cell 0
+- id: 315010-0001748
+  revision: 0
+  address: ran-simulator:5960
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001748"
+    grpcport: "5960"
+    latitude: "52.649904"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 269 Cell 1
+- id: 315010-0001749
+  revision: 0
+  address: ran-simulator:5961
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001749"
+    grpcport: "5961"
+    latitude: "52.649904"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 269 Cell 2
+- id: 315010-000174a
+  revision: 0
+  address: ran-simulator:5962
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000174a
+    grpcport: "5962"
+    latitude: "52.675885"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 270 Cell 0
+- id: 315010-000174b
+  revision: 0
+  address: ran-simulator:5963
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000174b
+    grpcport: "5963"
+    latitude: "52.675885"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 270 Cell 1
+- id: 315010-000174c
+  revision: 0
+  address: ran-simulator:5964
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000174c
+    grpcport: "5964"
+    latitude: "52.675885"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 270 Cell 2
+- id: 315010-000174d
+  revision: 0
+  address: ran-simulator:5965
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000174d
+    grpcport: "5965"
+    latitude: "52.701865"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 271 Cell 0
+- id: 315010-000174e
+  revision: 0
+  address: ran-simulator:5966
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000174e
+    grpcport: "5966"
+    latitude: "52.701865"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 271 Cell 1
+- id: 315010-000174f
+  revision: 0
+  address: ran-simulator:5967
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000174f
+    grpcport: "5967"
+    latitude: "52.701865"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 271 Cell 2
+- id: 315010-0001750
+  revision: 0
+  address: ran-simulator:5968
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001750"
+    grpcport: "5968"
+    latitude: "52.727846"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 272 Cell 0
+- id: 315010-0001751
+  revision: 0
+  address: ran-simulator:5969
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001751"
+    grpcport: "5969"
+    latitude: "52.727846"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 272 Cell 1
+- id: 315010-0001752
+  revision: 0
+  address: ran-simulator:5970
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001752"
+    grpcport: "5970"
+    latitude: "52.727846"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 272 Cell 2
+- id: 315010-0001753
+  revision: 0
+  address: ran-simulator:5971
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001753"
+    grpcport: "5971"
+    latitude: "52.753827"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 273 Cell 0
+- id: 315010-0001754
+  revision: 0
+  address: ran-simulator:5972
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001754"
+    grpcport: "5972"
+    latitude: "52.753827"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 273 Cell 1
+- id: 315010-0001755
+  revision: 0
+  address: ran-simulator:5973
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001755"
+    grpcport: "5973"
+    latitude: "52.753827"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 273 Cell 2
+- id: 315010-0001756
+  revision: 0
+  address: ran-simulator:5974
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001756"
+    grpcport: "5974"
+    latitude: "52.779808"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 274 Cell 0
+- id: 315010-0001757
+  revision: 0
+  address: ran-simulator:5975
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001757"
+    grpcport: "5975"
+    latitude: "52.779808"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 274 Cell 1
+- id: 315010-0001758
+  revision: 0
+  address: ran-simulator:5976
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001758"
+    grpcport: "5976"
+    latitude: "52.779808"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 274 Cell 2
+- id: 315010-0001759
+  revision: 0
+  address: ran-simulator:5977
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001759"
+    grpcport: "5977"
+    latitude: "52.805788"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 275 Cell 0
+- id: 315010-000175a
+  revision: 0
+  address: ran-simulator:5978
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000175a
+    grpcport: "5978"
+    latitude: "52.805788"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 275 Cell 1
+- id: 315010-000175b
+  revision: 0
+  address: ran-simulator:5979
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000175b
+    grpcport: "5979"
+    latitude: "52.805788"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 275 Cell 2
+- id: 315010-000175c
+  revision: 0
+  address: ran-simulator:5980
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000175c
+    grpcport: "5980"
+    latitude: "52.831769"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 276 Cell 0
+- id: 315010-000175d
+  revision: 0
+  address: ran-simulator:5981
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000175d
+    grpcport: "5981"
+    latitude: "52.831769"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 276 Cell 1
+- id: 315010-000175e
+  revision: 0
+  address: ran-simulator:5982
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000175e
+    grpcport: "5982"
+    latitude: "52.831769"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 276 Cell 2
+- id: 315010-000175f
+  revision: 0
+  address: ran-simulator:5983
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000175f
+    grpcport: "5983"
+    latitude: "52.857750"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 277 Cell 0
+- id: 315010-0001760
+  revision: 0
+  address: ran-simulator:5984
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001760"
+    grpcport: "5984"
+    latitude: "52.857750"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 277 Cell 1
+- id: 315010-0001761
+  revision: 0
+  address: ran-simulator:5985
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001761"
+    grpcport: "5985"
+    latitude: "52.857750"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 277 Cell 2
+- id: 315010-0001762
+  revision: 0
+  address: ran-simulator:5986
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001762"
+    grpcport: "5986"
+    latitude: "52.883731"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 278 Cell 0
+- id: 315010-0001763
+  revision: 0
+  address: ran-simulator:5987
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001763"
+    grpcport: "5987"
+    latitude: "52.883731"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 278 Cell 1
+- id: 315010-0001764
+  revision: 0
+  address: ran-simulator:5988
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001764"
+    grpcport: "5988"
+    latitude: "52.883731"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 278 Cell 2
+- id: 315010-0001765
+  revision: 0
+  address: ran-simulator:5989
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001765"
+    grpcport: "5989"
+    latitude: "52.909711"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 279 Cell 0
+- id: 315010-0001766
+  revision: 0
+  address: ran-simulator:5990
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001766"
+    grpcport: "5990"
+    latitude: "52.909711"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 279 Cell 1
+- id: 315010-0001767
+  revision: 0
+  address: ran-simulator:5991
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001767"
+    grpcport: "5991"
+    latitude: "52.909711"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 279 Cell 2
+- id: 315010-0001768
+  revision: 0
+  address: ran-simulator:5992
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001768"
+    grpcport: "5992"
+    latitude: "52.935692"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 280 Cell 0
+- id: 315010-0001769
+  revision: 0
+  address: ran-simulator:5993
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001769"
+    grpcport: "5993"
+    latitude: "52.935692"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 280 Cell 1
+- id: 315010-000176a
+  revision: 0
+  address: ran-simulator:5994
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000176a
+    grpcport: "5994"
+    latitude: "52.935692"
+    longitude: "13.700817"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 280 Cell 2
+- id: 315010-000176b
+  revision: 0
+  address: ran-simulator:5995
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000176b
+    grpcport: "5995"
+    latitude: "52.623923"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 281 Cell 0
+- id: 315010-000176c
+  revision: 0
+  address: ran-simulator:5996
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000176c
+    grpcport: "5996"
+    latitude: "52.623923"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 281 Cell 1
+- id: 315010-000176d
+  revision: 0
+  address: ran-simulator:5997
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000176d
+    grpcport: "5997"
+    latitude: "52.623923"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 281 Cell 2
+- id: 315010-000176e
+  revision: 0
+  address: ran-simulator:5998
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000176e
+    grpcport: "5998"
+    latitude: "52.649904"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 282 Cell 0
+- id: 315010-000176f
+  revision: 0
+  address: ran-simulator:5999
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000176f
+    grpcport: "5999"
+    latitude: "52.649904"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 282 Cell 1
+- id: 315010-0001770
+  revision: 0
+  address: ran-simulator:6000
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001770"
+    grpcport: "6000"
+    latitude: "52.649904"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 282 Cell 2
+- id: 315010-0001771
+  revision: 0
+  address: ran-simulator:6001
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001771"
+    grpcport: "6001"
+    latitude: "52.675885"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 283 Cell 0
+- id: 315010-0001772
+  revision: 0
+  address: ran-simulator:6002
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001772"
+    grpcport: "6002"
+    latitude: "52.675885"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 283 Cell 1
+- id: 315010-0001773
+  revision: 0
+  address: ran-simulator:6003
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001773"
+    grpcport: "6003"
+    latitude: "52.675885"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 283 Cell 2
+- id: 315010-0001774
+  revision: 0
+  address: ran-simulator:6004
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001774"
+    grpcport: "6004"
+    latitude: "52.701865"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 284 Cell 0
+- id: 315010-0001775
+  revision: 0
+  address: ran-simulator:6005
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001775"
+    grpcport: "6005"
+    latitude: "52.701865"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 284 Cell 1
+- id: 315010-0001776
+  revision: 0
+  address: ran-simulator:6006
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001776"
+    grpcport: "6006"
+    latitude: "52.701865"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 284 Cell 2
+- id: 315010-0001777
+  revision: 0
+  address: ran-simulator:6007
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001777"
+    grpcport: "6007"
+    latitude: "52.727846"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 285 Cell 0
+- id: 315010-0001778
+  revision: 0
+  address: ran-simulator:6008
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001778"
+    grpcport: "6008"
+    latitude: "52.727846"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 285 Cell 1
+- id: 315010-0001779
+  revision: 0
+  address: ran-simulator:6009
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001779"
+    grpcport: "6009"
+    latitude: "52.727846"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 285 Cell 2
+- id: 315010-000177a
+  revision: 0
+  address: ran-simulator:6010
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000177a
+    grpcport: "6010"
+    latitude: "52.753827"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 286 Cell 0
+- id: 315010-000177b
+  revision: 0
+  address: ran-simulator:6011
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000177b
+    grpcport: "6011"
+    latitude: "52.753827"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 286 Cell 1
+- id: 315010-000177c
+  revision: 0
+  address: ran-simulator:6012
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000177c
+    grpcport: "6012"
+    latitude: "52.753827"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 286 Cell 2
+- id: 315010-000177d
+  revision: 0
+  address: ran-simulator:6013
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000177d
+    grpcport: "6013"
+    latitude: "52.779808"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 287 Cell 0
+- id: 315010-000177e
+  revision: 0
+  address: ran-simulator:6014
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000177e
+    grpcport: "6014"
+    latitude: "52.779808"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 287 Cell 1
+- id: 315010-000177f
+  revision: 0
+  address: ran-simulator:6015
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000177f
+    grpcport: "6015"
+    latitude: "52.779808"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 287 Cell 2
+- id: 315010-0001780
+  revision: 0
+  address: ran-simulator:6016
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001780"
+    grpcport: "6016"
+    latitude: "52.805788"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 288 Cell 0
+- id: 315010-0001781
+  revision: 0
+  address: ran-simulator:6017
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001781"
+    grpcport: "6017"
+    latitude: "52.805788"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 288 Cell 1
+- id: 315010-0001782
+  revision: 0
+  address: ran-simulator:6018
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001782"
+    grpcport: "6018"
+    latitude: "52.805788"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 288 Cell 2
+- id: 315010-0001783
+  revision: 0
+  address: ran-simulator:6019
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001783"
+    grpcport: "6019"
+    latitude: "52.831769"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 289 Cell 0
+- id: 315010-0001784
+  revision: 0
+  address: ran-simulator:6020
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001784"
+    grpcport: "6020"
+    latitude: "52.831769"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 289 Cell 1
+- id: 315010-0001785
+  revision: 0
+  address: ran-simulator:6021
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001785"
+    grpcport: "6021"
+    latitude: "52.831769"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 289 Cell 2
+- id: 315010-0001786
+  revision: 0
+  address: ran-simulator:6022
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001786"
+    grpcport: "6022"
+    latitude: "52.857750"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 290 Cell 0
+- id: 315010-0001787
+  revision: 0
+  address: ran-simulator:6023
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001787"
+    grpcport: "6023"
+    latitude: "52.857750"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 290 Cell 1
+- id: 315010-0001788
+  revision: 0
+  address: ran-simulator:6024
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001788"
+    grpcport: "6024"
+    latitude: "52.857750"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 290 Cell 2
+- id: 315010-0001789
+  revision: 0
+  address: ran-simulator:6025
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001789"
+    grpcport: "6025"
+    latitude: "52.883731"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 291 Cell 0
+- id: 315010-000178a
+  revision: 0
+  address: ran-simulator:6026
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000178a
+    grpcport: "6026"
+    latitude: "52.883731"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 291 Cell 1
+- id: 315010-000178b
+  revision: 0
+  address: ran-simulator:6027
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000178b
+    grpcport: "6027"
+    latitude: "52.883731"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 291 Cell 2
+- id: 315010-000178c
+  revision: 0
+  address: ran-simulator:6028
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000178c
+    grpcport: "6028"
+    latitude: "52.909711"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 292 Cell 0
+- id: 315010-000178d
+  revision: 0
+  address: ran-simulator:6029
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000178d
+    grpcport: "6029"
+    latitude: "52.909711"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 292 Cell 1
+- id: 315010-000178e
+  revision: 0
+  address: ran-simulator:6030
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000178e
+    grpcport: "6030"
+    latitude: "52.909711"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 292 Cell 2
+- id: 315010-000178f
+  revision: 0
+  address: ran-simulator:6031
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000178f
+    grpcport: "6031"
+    latitude: "52.935692"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 293 Cell 0
+- id: 315010-0001790
+  revision: 0
+  address: ran-simulator:6032
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001790"
+    grpcport: "6032"
+    latitude: "52.935692"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 293 Cell 1
+- id: 315010-0001791
+  revision: 0
+  address: ran-simulator:6033
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001791"
+    grpcport: "6033"
+    latitude: "52.935692"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 293 Cell 2
+- id: 315010-0001792
+  revision: 0
+  address: ran-simulator:6034
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001792"
+    grpcport: "6034"
+    latitude: "52.961673"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 294 Cell 0
+- id: 315010-0001793
+  revision: 0
+  address: ran-simulator:6035
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001793"
+    grpcport: "6035"
+    latitude: "52.961673"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 294 Cell 1
+- id: 315010-0001794
+  revision: 0
+  address: ran-simulator:6036
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001794"
+    grpcport: "6036"
+    latitude: "52.961673"
+    longitude: "13.626863"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 294 Cell 2
+- id: 315010-0001795
+  revision: 0
+  address: ran-simulator:6037
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001795"
+    grpcport: "6037"
+    latitude: "52.675885"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 295 Cell 0
+- id: 315010-0001796
+  revision: 0
+  address: ran-simulator:6038
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001796"
+    grpcport: "6038"
+    latitude: "52.675885"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 295 Cell 1
+- id: 315010-0001797
+  revision: 0
+  address: ran-simulator:6039
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001797"
+    grpcport: "6039"
+    latitude: "52.675885"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 295 Cell 2
+- id: 315010-0001798
+  revision: 0
+  address: ran-simulator:6040
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001798"
+    grpcport: "6040"
+    latitude: "52.701865"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 296 Cell 0
+- id: 315010-0001799
+  revision: 0
+  address: ran-simulator:6041
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001799"
+    grpcport: "6041"
+    latitude: "52.701865"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 296 Cell 1
+- id: 315010-000179a
+  revision: 0
+  address: ran-simulator:6042
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000179a
+    grpcport: "6042"
+    latitude: "52.701865"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 296 Cell 2
+- id: 315010-000179b
+  revision: 0
+  address: ran-simulator:6043
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000179b
+    grpcport: "6043"
+    latitude: "52.727846"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 297 Cell 0
+- id: 315010-000179c
+  revision: 0
+  address: ran-simulator:6044
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000179c
+    grpcport: "6044"
+    latitude: "52.727846"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 297 Cell 1
+- id: 315010-000179d
+  revision: 0
+  address: ran-simulator:6045
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000179d
+    grpcport: "6045"
+    latitude: "52.727846"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 297 Cell 2
+- id: 315010-000179e
+  revision: 0
+  address: ran-simulator:6046
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 000179e
+    grpcport: "6046"
+    latitude: "52.753827"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 298 Cell 0
+- id: 315010-000179f
+  revision: 0
+  address: ran-simulator:6047
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000179f
+    grpcport: "6047"
+    latitude: "52.753827"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 298 Cell 1
+- id: 315010-00017a0
+  revision: 0
+  address: ran-simulator:6048
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017a0
+    grpcport: "6048"
+    latitude: "52.753827"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 298 Cell 2
+- id: 315010-00017a1
+  revision: 0
+  address: ran-simulator:6049
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017a1
+    grpcport: "6049"
+    latitude: "52.779808"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 299 Cell 0
+- id: 315010-00017a2
+  revision: 0
+  address: ran-simulator:6050
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017a2
+    grpcport: "6050"
+    latitude: "52.779808"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 299 Cell 1
+- id: 315010-00017a3
+  revision: 0
+  address: ran-simulator:6051
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017a3
+    grpcport: "6051"
+    latitude: "52.779808"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 299 Cell 2
+- id: 315010-00017a4
+  revision: 0
+  address: ran-simulator:6052
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017a4
+    grpcport: "6052"
+    latitude: "52.805788"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 300 Cell 0
+- id: 315010-00017a5
+  revision: 0
+  address: ran-simulator:6053
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017a5
+    grpcport: "6053"
+    latitude: "52.805788"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 300 Cell 1
+- id: 315010-00017a6
+  revision: 0
+  address: ran-simulator:6054
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017a6
+    grpcport: "6054"
+    latitude: "52.805788"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 300 Cell 2
+- id: 315010-00017a7
+  revision: 0
+  address: ran-simulator:6055
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017a7
+    grpcport: "6055"
+    latitude: "52.831769"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 301 Cell 0
+- id: 315010-00017a8
+  revision: 0
+  address: ran-simulator:6056
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017a8
+    grpcport: "6056"
+    latitude: "52.831769"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 301 Cell 1
+- id: 315010-00017a9
+  revision: 0
+  address: ran-simulator:6057
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017a9
+    grpcport: "6057"
+    latitude: "52.831769"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 301 Cell 2
+- id: 315010-00017aa
+  revision: 0
+  address: ran-simulator:6058
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017aa
+    grpcport: "6058"
+    latitude: "52.857750"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 302 Cell 0
+- id: 315010-00017ab
+  revision: 0
+  address: ran-simulator:6059
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017ab
+    grpcport: "6059"
+    latitude: "52.857750"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 302 Cell 1
+- id: 315010-00017ac
+  revision: 0
+  address: ran-simulator:6060
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017ac
+    grpcport: "6060"
+    latitude: "52.857750"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 302 Cell 2
+- id: 315010-00017ad
+  revision: 0
+  address: ran-simulator:6061
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017ad
+    grpcport: "6061"
+    latitude: "52.883731"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 303 Cell 0
+- id: 315010-00017ae
+  revision: 0
+  address: ran-simulator:6062
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017ae
+    grpcport: "6062"
+    latitude: "52.883731"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 303 Cell 1
+- id: 315010-00017af
+  revision: 0
+  address: ran-simulator:6063
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017af
+    grpcport: "6063"
+    latitude: "52.883731"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 303 Cell 2
+- id: 315010-00017b0
+  revision: 0
+  address: ran-simulator:6064
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017b0
+    grpcport: "6064"
+    latitude: "52.909711"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 304 Cell 0
+- id: 315010-00017b1
+  revision: 0
+  address: ran-simulator:6065
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017b1
+    grpcport: "6065"
+    latitude: "52.909711"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 304 Cell 1
+- id: 315010-00017b2
+  revision: 0
+  address: ran-simulator:6066
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017b2
+    grpcport: "6066"
+    latitude: "52.909711"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 304 Cell 2
+- id: 315010-00017b3
+  revision: 0
+  address: ran-simulator:6067
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017b3
+    grpcport: "6067"
+    latitude: "52.935692"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 305 Cell 0
+- id: 315010-00017b4
+  revision: 0
+  address: ran-simulator:6068
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017b4
+    grpcport: "6068"
+    latitude: "52.935692"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 305 Cell 1
+- id: 315010-00017b5
+  revision: 0
+  address: ran-simulator:6069
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017b5
+    grpcport: "6069"
+    latitude: "52.935692"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 305 Cell 2
+- id: 315010-00017b6
+  revision: 0
+  address: ran-simulator:6070
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017b6
+    grpcport: "6070"
+    latitude: "52.961673"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 306 Cell 0
+- id: 315010-00017b7
+  revision: 0
+  address: ran-simulator:6071
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017b7
+    grpcport: "6071"
+    latitude: "52.961673"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 306 Cell 1
+- id: 315010-00017b8
+  revision: 0
+  address: ran-simulator:6072
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017b8
+    grpcport: "6072"
+    latitude: "52.961673"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 306 Cell 2
+- id: 315010-00017b9
+  revision: 0
+  address: ran-simulator:6073
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017b9
+    grpcport: "6073"
+    latitude: "52.987654"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 307 Cell 0
+- id: 315010-00017ba
+  revision: 0
+  address: ran-simulator:6074
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017ba
+    grpcport: "6074"
+    latitude: "52.987654"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 307 Cell 1
+- id: 315010-00017bb
+  revision: 0
+  address: ran-simulator:6075
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017bb
+    grpcport: "6075"
+    latitude: "52.987654"
+    longitude: "13.552908"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 307 Cell 2
+- id: 315010-00017bc
+  revision: 0
+  address: ran-simulator:6076
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017bc
+    grpcport: "6076"
+    latitude: "52.727846"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 308 Cell 0
+- id: 315010-00017bd
+  revision: 0
+  address: ran-simulator:6077
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017bd
+    grpcport: "6077"
+    latitude: "52.727846"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 308 Cell 1
+- id: 315010-00017be
+  revision: 0
+  address: ran-simulator:6078
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017be
+    grpcport: "6078"
+    latitude: "52.727846"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 308 Cell 2
+- id: 315010-00017bf
+  revision: 0
+  address: ran-simulator:6079
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017bf
+    grpcport: "6079"
+    latitude: "52.753827"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 309 Cell 0
+- id: 315010-00017c0
+  revision: 0
+  address: ran-simulator:6080
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017c0
+    grpcport: "6080"
+    latitude: "52.753827"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 309 Cell 1
+- id: 315010-00017c1
+  revision: 0
+  address: ran-simulator:6081
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017c1
+    grpcport: "6081"
+    latitude: "52.753827"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 309 Cell 2
+- id: 315010-00017c2
+  revision: 0
+  address: ran-simulator:6082
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017c2
+    grpcport: "6082"
+    latitude: "52.779808"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 310 Cell 0
+- id: 315010-00017c3
+  revision: 0
+  address: ran-simulator:6083
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017c3
+    grpcport: "6083"
+    latitude: "52.779808"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 310 Cell 1
+- id: 315010-00017c4
+  revision: 0
+  address: ran-simulator:6084
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017c4
+    grpcport: "6084"
+    latitude: "52.779808"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 310 Cell 2
+- id: 315010-00017c5
+  revision: 0
+  address: ran-simulator:6085
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017c5
+    grpcport: "6085"
+    latitude: "52.805788"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 311 Cell 0
+- id: 315010-00017c6
+  revision: 0
+  address: ran-simulator:6086
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017c6
+    grpcport: "6086"
+    latitude: "52.805788"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 311 Cell 1
+- id: 315010-00017c7
+  revision: 0
+  address: ran-simulator:6087
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017c7
+    grpcport: "6087"
+    latitude: "52.805788"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 311 Cell 2
+- id: 315010-00017c8
+  revision: 0
+  address: ran-simulator:6088
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017c8
+    grpcport: "6088"
+    latitude: "52.831769"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 312 Cell 0
+- id: 315010-00017c9
+  revision: 0
+  address: ran-simulator:6089
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017c9
+    grpcport: "6089"
+    latitude: "52.831769"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 312 Cell 1
+- id: 315010-00017ca
+  revision: 0
+  address: ran-simulator:6090
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017ca
+    grpcport: "6090"
+    latitude: "52.831769"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 312 Cell 2
+- id: 315010-00017cb
+  revision: 0
+  address: ran-simulator:6091
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017cb
+    grpcport: "6091"
+    latitude: "52.857750"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 313 Cell 0
+- id: 315010-00017cc
+  revision: 0
+  address: ran-simulator:6092
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017cc
+    grpcport: "6092"
+    latitude: "52.857750"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 313 Cell 1
+- id: 315010-00017cd
+  revision: 0
+  address: ran-simulator:6093
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017cd
+    grpcport: "6093"
+    latitude: "52.857750"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 313 Cell 2
+- id: 315010-00017ce
+  revision: 0
+  address: ran-simulator:6094
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017ce
+    grpcport: "6094"
+    latitude: "52.883731"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 314 Cell 0
+- id: 315010-00017cf
+  revision: 0
+  address: ran-simulator:6095
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017cf
+    grpcport: "6095"
+    latitude: "52.883731"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 314 Cell 1
+- id: 315010-00017d0
+  revision: 0
+  address: ran-simulator:6096
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017d0
+    grpcport: "6096"
+    latitude: "52.883731"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 314 Cell 2
+- id: 315010-00017d1
+  revision: 0
+  address: ran-simulator:6097
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017d1
+    grpcport: "6097"
+    latitude: "52.909711"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 315 Cell 0
+- id: 315010-00017d2
+  revision: 0
+  address: ran-simulator:6098
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017d2
+    grpcport: "6098"
+    latitude: "52.909711"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 315 Cell 1
+- id: 315010-00017d3
+  revision: 0
+  address: ran-simulator:6099
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017d3
+    grpcport: "6099"
+    latitude: "52.909711"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 315 Cell 2
+- id: 315010-00017d4
+  revision: 0
+  address: ran-simulator:6100
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017d4
+    grpcport: "6100"
+    latitude: "52.935692"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 316 Cell 0
+- id: 315010-00017d5
+  revision: 0
+  address: ran-simulator:6101
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017d5
+    grpcport: "6101"
+    latitude: "52.935692"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 316 Cell 1
+- id: 315010-00017d6
+  revision: 0
+  address: ran-simulator:6102
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017d6
+    grpcport: "6102"
+    latitude: "52.935692"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 316 Cell 2
+- id: 315010-00017d7
+  revision: 0
+  address: ran-simulator:6103
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017d7
+    grpcport: "6103"
+    latitude: "52.961673"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 317 Cell 0
+- id: 315010-00017d8
+  revision: 0
+  address: ran-simulator:6104
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017d8
+    grpcport: "6104"
+    latitude: "52.961673"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 317 Cell 1
+- id: 315010-00017d9
+  revision: 0
+  address: ran-simulator:6105
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017d9
+    grpcport: "6105"
+    latitude: "52.961673"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 317 Cell 2
+- id: 315010-00017da
+  revision: 0
+  address: ran-simulator:6106
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017da
+    grpcport: "6106"
+    latitude: "52.987654"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 318 Cell 0
+- id: 315010-00017db
+  revision: 0
+  address: ran-simulator:6107
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017db
+    grpcport: "6107"
+    latitude: "52.987654"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 318 Cell 1
+- id: 315010-00017dc
+  revision: 0
+  address: ran-simulator:6108
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017dc
+    grpcport: "6108"
+    latitude: "52.987654"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 318 Cell 2
+- id: 315010-00017dd
+  revision: 0
+  address: ran-simulator:6109
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017dd
+    grpcport: "6109"
+    latitude: "53.013634"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 319 Cell 0
+- id: 315010-00017de
+  revision: 0
+  address: ran-simulator:6110
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017de
+    grpcport: "6110"
+    latitude: "53.013634"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 319 Cell 1
+- id: 315010-00017df
+  revision: 0
+  address: ran-simulator:6111
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017df
+    grpcport: "6111"
+    latitude: "53.013634"
+    longitude: "13.478954"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 319 Cell 2
+- id: 315010-00017e0
+  revision: 0
+  address: ran-simulator:6112
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00017e0"
+    grpcport: "6112"
+    latitude: "52.779808"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 320 Cell 0
+- id: 315010-00017e1
+  revision: 0
+  address: ran-simulator:6113
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00017e1"
+    grpcport: "6113"
+    latitude: "52.779808"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 320 Cell 1
+- id: 315010-00017e2
+  revision: 0
+  address: ran-simulator:6114
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00017e2"
+    grpcport: "6114"
+    latitude: "52.779808"
+    longitude: "12.665458"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 320 Cell 2
+- id: 315010-00017e3
+  revision: 0
+  address: ran-simulator:6115
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00017e3"
+    grpcport: "6115"
+    latitude: "52.805788"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 321 Cell 0
+- id: 315010-00017e4
+  revision: 0
+  address: ran-simulator:6116
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00017e4"
+    grpcport: "6116"
+    latitude: "52.805788"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 321 Cell 1
+- id: 315010-00017e5
+  revision: 0
+  address: ran-simulator:6117
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00017e5"
+    grpcport: "6117"
+    latitude: "52.805788"
+    longitude: "12.739412"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 321 Cell 2
+- id: 315010-00017e6
+  revision: 0
+  address: ran-simulator:6118
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00017e6"
+    grpcport: "6118"
+    latitude: "52.831769"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 322 Cell 0
+- id: 315010-00017e7
+  revision: 0
+  address: ran-simulator:6119
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "00017e7"
+    grpcport: "6119"
+    latitude: "52.831769"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 322 Cell 1
+- id: 315010-00017e8
+  revision: 0
+  address: ran-simulator:6120
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "00017e8"
+    grpcport: "6120"
+    latitude: "52.831769"
+    longitude: "12.813366"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 322 Cell 2
+- id: 315010-00017e9
+  revision: 0
+  address: ran-simulator:6121
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "00017e9"
+    grpcport: "6121"
+    latitude: "52.857750"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 323 Cell 0
+- id: 315010-00017ea
+  revision: 0
+  address: ran-simulator:6122
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017ea
+    grpcport: "6122"
+    latitude: "52.857750"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 323 Cell 1
+- id: 315010-00017eb
+  revision: 0
+  address: ran-simulator:6123
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017eb
+    grpcport: "6123"
+    latitude: "52.857750"
+    longitude: "12.887320"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 323 Cell 2
+- id: 315010-00017ec
+  revision: 0
+  address: ran-simulator:6124
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017ec
+    grpcport: "6124"
+    latitude: "52.883731"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 324 Cell 0
+- id: 315010-00017ed
+  revision: 0
+  address: ran-simulator:6125
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017ed
+    grpcport: "6125"
+    latitude: "52.883731"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 324 Cell 1
+- id: 315010-00017ee
+  revision: 0
+  address: ran-simulator:6126
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017ee
+    grpcport: "6126"
+    latitude: "52.883731"
+    longitude: "12.961275"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 324 Cell 2
+- id: 315010-00017ef
+  revision: 0
+  address: ran-simulator:6127
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017ef
+    grpcport: "6127"
+    latitude: "52.909711"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 325 Cell 0
+- id: 315010-00017f0
+  revision: 0
+  address: ran-simulator:6128
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017f0
+    grpcport: "6128"
+    latitude: "52.909711"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 325 Cell 1
+- id: 315010-00017f1
+  revision: 0
+  address: ran-simulator:6129
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017f1
+    grpcport: "6129"
+    latitude: "52.909711"
+    longitude: "13.035229"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 325 Cell 2
+- id: 315010-00017f2
+  revision: 0
+  address: ran-simulator:6130
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017f2
+    grpcport: "6130"
+    latitude: "52.935692"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 326 Cell 0
+- id: 315010-00017f3
+  revision: 0
+  address: ran-simulator:6131
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017f3
+    grpcport: "6131"
+    latitude: "52.935692"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 326 Cell 1
+- id: 315010-00017f4
+  revision: 0
+  address: ran-simulator:6132
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017f4
+    grpcport: "6132"
+    latitude: "52.935692"
+    longitude: "13.109183"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 326 Cell 2
+- id: 315010-00017f5
+  revision: 0
+  address: ran-simulator:6133
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017f5
+    grpcport: "6133"
+    latitude: "52.961673"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 327 Cell 0
+- id: 315010-00017f6
+  revision: 0
+  address: ran-simulator:6134
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017f6
+    grpcport: "6134"
+    latitude: "52.961673"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 327 Cell 1
+- id: 315010-00017f7
+  revision: 0
+  address: ran-simulator:6135
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017f7
+    grpcport: "6135"
+    latitude: "52.961673"
+    longitude: "13.183137"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 327 Cell 2
+- id: 315010-00017f8
+  revision: 0
+  address: ran-simulator:6136
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017f8
+    grpcport: "6136"
+    latitude: "52.987654"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 328 Cell 0
+- id: 315010-00017f9
+  revision: 0
+  address: ran-simulator:6137
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017f9
+    grpcport: "6137"
+    latitude: "52.987654"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 328 Cell 1
+- id: 315010-00017fa
+  revision: 0
+  address: ran-simulator:6138
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017fa
+    grpcport: "6138"
+    latitude: "52.987654"
+    longitude: "13.257092"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 328 Cell 2
+- id: 315010-00017fb
+  revision: 0
+  address: ran-simulator:6139
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017fb
+    grpcport: "6139"
+    latitude: "53.013634"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 329 Cell 0
+- id: 315010-00017fc
+  revision: 0
+  address: ran-simulator:6140
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017fc
+    grpcport: "6140"
+    latitude: "53.013634"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 329 Cell 1
+- id: 315010-00017fd
+  revision: 0
+  address: ran-simulator:6141
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 00017fd
+    grpcport: "6141"
+    latitude: "53.013634"
+    longitude: "13.331046"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 329 Cell 2
+- id: 315010-00017fe
+  revision: 0
+  address: ran-simulator:6142
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: 00017fe
+    grpcport: "6142"
+    latitude: "53.039615"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 330 Cell 0
+- id: 315010-00017ff
+  revision: 0
+  address: ran-simulator:6143
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 00017ff
+    grpcport: "6143"
+    latitude: "53.039615"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 330 Cell 1
+- id: 315010-0001800
+  revision: 0
+  address: ran-simulator:6144
+  target: ""
+  version: 1.0.0
+  timeout: null
+  credentials:
+    user: ""
+    password: ""
+  tls:
+    cacert: ""
+    cert: ""
+    key: ""
+    plain: false
+    insecure: true
+  type: E2Node
+  role: ""
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001800"
+    grpcport: "6144"
+    latitude: "53.039615"
+    longitude: "13.405000"
+    plmnid: "315010"
+  protocols: []
+  displayname: Tower 330 Cell 2

--- a/sd-ran/files/configs/berlin-honeycomb-4-3-gnmi.yaml
+++ b/sd-ran/files/configs/berlin-honeycomb-4-3-gnmi.yaml
@@ -1,0 +1,204 @@
+setrequest:
+  prefix:
+    elem:
+    - name: e2node
+  delete: []
+  replace: []
+  update:
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001420
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001420
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001421
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001421
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001422
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001422
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001423
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001423
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001424
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001424
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001425
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001425
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001426
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001426
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001427
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001427
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001428
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001428
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-0001429
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-0001429
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142a
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142a
+    val:
+      uintvalue:
+        uintval: 21
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerUe
+      target: 315010-000142b
+    val:
+      uintvalue:
+        uintval: 20
+  - path:
+      elem:
+      - name: intervals
+      - name: RadioMeasReportPerCell
+      target: 315010-000142b
+    val:
+      uintvalue:
+        uintval: 21
+  extension:
+  - id: 101
+    value: 1.0.0
+  - id: 102
+    value: E2Node

--- a/sd-ran/files/configs/berlin-honeycomb-4-3-topo.yaml
+++ b/sd-ran/files/configs/berlin-honeycomb-4-3-topo.yaml
@@ -1,0 +1,182 @@
+topodevices:
+- id: 315010-0001420
+  address: ran-simulator:5152
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001420"
+    grpcport: "5152"
+    latitude: "52.485359"
+    longitude: "13.405000"
+    plmnid: "315010"
+  displayname: Tower 0 Cell 0
+- id: 315010-0001421
+  address: ran-simulator:5153
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001421"
+    grpcport: "5153"
+    latitude: "52.485359"
+    longitude: "13.405000"
+    plmnid: "315010"
+  displayname: Tower 0 Cell 1
+- id: 315010-0001422
+  address: ran-simulator:5154
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001422"
+    grpcport: "5154"
+    latitude: "52.485359"
+    longitude: "13.405000"
+    plmnid: "315010"
+  displayname: Tower 0 Cell 2
+- id: 315010-0001423
+  address: ran-simulator:5155
+  version: 1.0.0
+  timeout: null
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001423"
+    grpcport: "5155"
+    latitude: "52.502679"
+    longitude: "13.454303"
+    plmnid: "315010"
+  displayname: Tower 1 Cell 0
+- id: 315010-0001424
+  address: ran-simulator:5156
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001424"
+    grpcport: "5156"
+    latitude: "52.502679"
+    longitude: "13.454303"
+    plmnid: "315010"
+  displayname: Tower 1 Cell 1
+- id: 315010-0001425
+  address: ran-simulator:5157
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001425"
+    grpcport: "5157"
+    latitude: "52.502679"
+    longitude: "13.454303"
+    plmnid: "315010"
+  displayname: Tower 1 Cell 2
+- id: 315010-0001426
+  address: ran-simulator:5158
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001426"
+    grpcport: "5158"
+    latitude: "52.502679"
+    longitude: "13.355697"
+    plmnid: "315010"
+  displayname: Tower 2 Cell 0
+- id: 315010-0001427
+  address: ran-simulator:5159
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: "0001427"
+    grpcport: "5159"
+    latitude: "52.502679"
+    longitude: "13.355697"
+    plmnid: "315010"
+  displayname: Tower 2 Cell 1
+- id: 315010-0001428
+  address: ran-simulator:5160
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: "0001428"
+    grpcport: "5160"
+    latitude: "52.502679"
+    longitude: "13.355697"
+    plmnid: "315010"
+  displayname: Tower 2 Cell 2
+- id: 315010-0001429
+  address: ran-simulator:5161
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "0"
+    ecid: "0001429"
+    grpcport: "5161"
+    latitude: "52.520000"
+    longitude: "13.405000"
+    plmnid: "315010"
+  displayname: Tower 3 Cell 0
+- id: 315010-000142a
+  address: ran-simulator:5162
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "120"
+    ecid: 000142a
+    grpcport: "5162"
+    latitude: "52.520000"
+    longitude: "13.405000"
+    plmnid: "315010"
+  displayname: Tower 3 Cell 1
+- id: 315010-000142b
+  address: ran-simulator:5163
+  version: 1.0.0
+  tls:
+    insecure: true
+  type: E2Node
+  attributes:
+    arc: "120"
+    azimuth: "240"
+    ecid: 000142b
+    grpcport: "5163"
+    latitude: "52.520000"
+    longitude: "13.405000"
+    plmnid: "315010"
+  displayname: Tower 3 Cell 2

--- a/sd-ran/templates/configmap.yaml
+++ b/sd-ran/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "onos-cli.fullname" . }}
+  name: {{ .Release.Name }}-post
   namespace: {{ .Release.Namespace }}
 data:
 {{ (.Files.Glob "files/configs/*.yaml").AsConfig | indent 2 }}

--- a/sd-ran/templates/post-install-job.yaml
+++ b/sd-ran/templates/post-install-job.yaml
@@ -24,9 +24,45 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: post-install-job
+        {{- if index .Values "import" "onos-topo" "enabled" }}
+          {{- if index .Values "onos-cli" "postInstall" "topo"}}
+        - name: post-install-topo-job
           image: {{ index .Values "onos-cli" "image" "repository" }}:{{ index .Values "onos-cli" "image" "tag" }}
           imagePullPolicy: {{ index .Values "onos-cli" "image" "pullPolicy" }}
           command: ["/usr/local/bin/onos"]
-#          TODO Change to `topo load yarn berlin-honeycomb-4-3-topo.yaml`
-          args: ["topo", "get", "devices"]
+          args:
+          - "topo"
+          - "load"
+          - "yaml"
+          - {{ index .Values "onos-cli" "postInstall" "topo" }}
+          volumeMounts:
+            - name: config
+              mountPath: /home/onos
+              readOnly: true
+          {{- end }}
+        {{- end }}
+        {{- if index .Values "import" "onos-config" "enabled" }}
+          {{- if index .Values "onos-cli" "postInstall" "config" }}
+        - name: post-install-config-job
+          image: {{ index .Values "onos-cli" "image" "repository" }}:{{ index .Values "onos-cli" "image" "tag" }}
+          imagePullPolicy: {{ index .Values "onos-cli" "image" "pullPolicy" }}
+          command: ["/usr/local/bin/onos"]
+          args:
+            - "config"
+            - "load"
+            - "yaml"
+            {{- with index .Values "onos-cli" "postInstall" "config" }}
+            {{- range $filename := . }}
+            - {{ $filename }}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /home/onos
+              readOnly: true
+          {{- end }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-post

--- a/sd-ran/values.yaml
+++ b/sd-ran/values.yaml
@@ -178,13 +178,13 @@ ran-simulator:
   showRoutes: true
   stepDelayMs: 1000
   zoom: 13
-  towerConfigName: berlin-honeycomb-4-3.yaml
 
 onos-cli:
   image:
     repository: onosproject/onos-cli
     tag: v0.6.5
     pullPolicy: IfNotPresent
-    postInstall:
-      - topo: berlin-honeycomb-4-3-topo.yaml
-        config: berlin-honeycomb-4-3-gnmi.yaml
+  postInstall:
+    placeholder: true
+    topo: berlin-honeycomb-4-3-topo.yaml
+    config: [ berlin-honeycomb-4-3-gnmi.yaml ]


### PR DESCRIPTION
Also fixed problem in onos-cli pod configmap

Removed unused param in ran-simulator