### PR TITLE
Use StatefulSet for peer-to-peer communication in onos-ric chart

### DIFF
--- a/onos-ric/Chart.yaml
+++ b/onos-ric/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-ric
 description: ONOS Radio Access Network Intelligent Controller
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: v0.6.6
 keywords:
   - onos

--- a/onos-ric/templates/service.yaml
+++ b/onos-ric/templates/service.yaml
@@ -23,6 +23,28 @@ spec:
     - name: exporter
       port: 7000
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "onos-ric.fullname" . }}-hs
+  labels:
+    app: {{ template "onos-ric.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "onos-ric.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    name: {{ template "onos-ric.fullname" . }}
+    app: onos
+    type: ran
+    resource: {{ template "onos-ric.fullname" . }}
+    {{- include "onos-ric.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc
+      port: 5678
+---
 {{- if .Values.service.external.nodePort }}
 apiVersion: v1
 kind: Service

--- a/onos-ric/templates/statefulset.yaml
+++ b/onos-ric/templates/statefulset.yaml
@@ -1,11 +1,14 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "onos-ric.fullname" . }}
   labels:
     {{- include "onos-ric.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       name: {{ template "onos-ric.fullname" . }}
@@ -13,6 +16,7 @@ spec:
       type: ran
       resource: {{ template "onos-ric.fullname" . }}
       {{- include "onos-ric.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "onos-ric.fullname" . }}-hs
   template:
     metadata:
       labels:
@@ -29,6 +33,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        - name: configure
+          image: ubuntu:16.04
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          command: ["/bin/sh", "-c", "printf \"%s.%s\" $(hostname -s) $(hostname -d) >> /config/id"]
+          volumeMounts:
+            - name: pod-id
+              mountPath: /config
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -54,6 +70,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          command:
+            - sh
+            - -c
+            - "POD_ID=$(cat /etc/onos/pod/id) onos-ric"
           args:
             - "-caPath=/etc/onos/certs/tls.cacrt"
             - "-keyPath=/etc/onos/certs/tls.key"
@@ -85,6 +105,9 @@ spec:
             - name: secret
               mountPath: /etc/onos/certs
               readOnly: true
+            - name: pod-id
+              mountPath: /etc/onos/pod
+              readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Enable ptrace for debugging
@@ -98,6 +121,8 @@ spec:
         - name: config
           configMap:
             name: {{ template "onos-ric.fullname" . }}-config
+        - name: pod-id
+          emptyDir: {}
         - name: secret
           secret:
             secretName: {{ template "onos-ric.fullname" . }}-secret

--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -23,7 +23,7 @@ dependencies:
   - name: atomix-controller
     condition: import.atomix-controller.enabled
     repository: https://charts.atomix.io
-    version: 0.5.0
+    version: 0.5.1
   - name: raft-storage-controller
     condition: import.atomix-raft-storage-controller.enabled
     repository: https://charts.atomix.io
@@ -34,8 +34,8 @@ dependencies:
     version: 0.4.0
   - name: onos-ric
     condition: import.onos-ric.enabled
-    repository: https://charts.onosproject.org
-    version: 0.0.7
+    repository: file://../onos-ric
+    version: 0.0.8
   - name: onos-ric-ho
     condition: import.onos-ric-ho.enabled
     repository: https://charts.onosproject.org


### PR DESCRIPTION
This PR modifies the onos-ric chart to use a `StatefulSet` with a headless `Service` to enable intracluster communication within the service. The pod network identity is extracted using an init container and is propagated to peers through the Atomix controller.

This PR should not be merged until the relevant changes to onos-ric are merged. Additionally, the sd-ran chart local `file://` dependency on the onos-ric chart should be updated before the sd-ran chart is released.