### PR TITLE
VOL-3110 : The helm chart uses two approaches

### DIFF
--- a/onos-classic/templates/_helpers.tpl
+++ b/onos-classic/templates/_helpers.tpl
@@ -18,3 +18,7 @@ We truncate at 60 chars because some Kubernetes name fields are limited to 63 (b
 {{- define "atomix.fullname" -}}
 {{- printf "%s-%s" .Release.Name "atomix" | trunc 59 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "livelinessApps" -}}
+{{- join "," .Values.apps }}
+{{- end -}}

--- a/onos-classic/templates/configmap-live-probe.yaml
+++ b/onos-classic/templates/configmap-live-probe.yaml
@@ -13,7 +13,7 @@ data:
     #!/bin/bash
     set -e
     live_probe () {
-        apps=$ONOS_APPS
+        apps=$(echo $LIVELINESS_CHECK_APPS | sed 's/[][]//g')
         IFS=',' read -ra app_array <<< "$apps"
         for i in "${app_array[@]}"
             do

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -71,8 +71,8 @@ spec:
         env:
           - name: JAVA_OPTS
             value: -Xmx{{ .Values.heap }}
-          - name: ONOS_APPS
-            value: {{ .Values.apps | quote }}
+          - name: LIVELINESS_CHECK_APPS
+            value: {{ template "livelinessApps" . }}
         ports:
           - name: openflow
             containerPort: 6653


### PR DESCRIPTION
1. using kind voltha, the ONOS_APPS reads as a string, hence there is no problem
2. using an independent helm chart, the ONOS_APPS reads as an array, which creates liveliness probes continuously.

Added new lively check apps, The livelinessCheckApps can be dynamically set using "helm --set " commands through helm charts.
In case the livelineessCheckApps variable is empty, apps will be considered from the ONOS_APPS environment variable.