### PR TITLE
Add a helm chart for stratum simulator

### DIFF
--- a/stratum-simulator/.helmignore
+++ b/stratum-simulator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stratum-simulator/Chart.yaml
+++ b/stratum-simulator/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: stratum-simulator
+description: Stratum Simulator
+kubeVersion: ">=1.15.0"
+type: application
+version: 0.0.1
+appVersion: v0.1.0
+keywords:
+  - onos
+  - sdn
+  - ran
+home: https://onosproject.org
+maintainers:
+  - name: Adib Rastegarnia
+    email: adib@opennetworking.org

--- a/stratum-simulator/templates/_helpers.tpl
+++ b/stratum-simulator/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "stratum-simulator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "stratum-simulator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "stratum-simulator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "stratum-simulator.labels" -}}
+helm.sh/chart: {{ include "stratum-simulator.chart" . }}
+{{ include "stratum-simulator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "stratum-simulator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "stratum-simulator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "stratum-simulator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "stratum-simulator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stratum-simulator/templates/deployment.yaml
+++ b/stratum-simulator/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "stratum-simulator.fullname" . }}
+  labels:
+    {{- include "stratum-simulator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "stratum-simulator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "stratum-simulator.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag}}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+                {{  range .Values.topospec.topology }}
+                - {{ . | quote }}
+                {{ end }}
+          ports:
+                  {{range $i, $e := until (.Values.topospec.num_devices | int)}}
+                  - name: stratum-{{ $i }}
+                    containerPort:  {{ add $.Values.service.port $i }}
+                  {{- end}}
+          readinessProbe:
+              tcpSocket:
+                port: {{ .Values.service.port }}
+              initialDelaySeconds: 5
+              periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.service.port}}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          stdin: true
+
+

--- a/stratum-simulator/templates/service.yaml
+++ b/stratum-simulator/templates/service.yaml
@@ -1,0 +1,19 @@
+{{- $fullName := include "stratum-simulator.fullname" . -}}
+{{- $labels := include "stratum-simulator.labels" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{ $labels | nindent 4 }}
+spec:
+  type: {{ $.Values.service.type }}
+  ports:
+          {{range $i, $e := until (.Values.topospec.num_devices | int)}}
+            - port: {{ add $.Values.service.port $i }}
+              name: "stratum-simulator-{{ $i }}"
+          {{- end }}
+  selector:
+    {{- include "stratum-simulator.selectorLabels" . | nindent 4 }}
+
+

--- a/stratum-simulator/values.yaml
+++ b/stratum-simulator/values.yaml
@@ -1,0 +1,25 @@
+# Default values for stratum-simulator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: opennetworking/mn-stratum
+  tag: latest
+  pullPolicy: IfNotPresent
+
+
+securityContext:
+  privileged: true
+
+service:
+  type: ClusterIP
+  port: 50001
+
+
+topospec:
+  num_devices: 2
+  topology:
+  - "--topo"
+  - "linear,2"


### PR DESCRIPTION
This PR adds a simple helm chart for stratum simulator that we can use it for ZTP.  In onit, we were exposing a service per gRPC port (I don't remember why but I think it makes more sense and easier to debug) but this one also works without adding complexity to helm chart using control flows (one service and exposes multiple gRPC ports) and perhaps in most of the cases we just need a single node scenario (i.e. --topo single). I tried to use range for service creation but it didn't work well so If I figure that out then I will update the PR.  I tested it using gNMI CLI to retrieve list of interfaces directly from the simulator. I should give it a try with onos-config as well.