### PR TITLE
Add the helm chart for ONOS-TOST

### DIFF
--- a/onos-tost/Chart.yaml
+++ b/onos-tost/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 name: onos-tost
 version: 0.1.1
 kubeVersion: ">=1.10.0"
-appVersion: 2.2.2
+appVersion: 2.2.3
 description: ONOS TOST
 keywords:
 - onos

--- a/onos-tost/Chart.yaml
+++ b/onos-tost/Chart.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+name: onos-tost
+version: 0.1.1
+kubeVersion: ">=1.10.0"
+appVersion: 2.2.2
+description: ONOS TOST
+keywords:
+- onos
+- sdn
+- networking
+home: http://onosproject.org
+icon: https://guide.opencord.org/logos/onos.svg
+maintainers:
+  - name: ONOS Support
+    email: support@opennetworking.org

--- a/onos-tost/Chart.yaml
+++ b/onos-tost/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-tost
-version: 0.1.1
+version: 0.1.2
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.3
 description: ONOS TOST

--- a/onos-tost/requirements.yaml
+++ b/onos-tost/requirements.yaml
@@ -1,0 +1,5 @@
+---
+dependencies:
+- name: onos-classic
+  version: 0.1.1
+  repository: https://charts.onosproject.org

--- a/onos-tost/values.yaml
+++ b/onos-tost/values.yaml
@@ -2,6 +2,7 @@ onos-classic:
   image: 
     repository: "onosproject/tost-onos"
     tag: "1.0.0-b1"
+  replicas: 3
   apps:
   - org.onosproject.drivers
   - org.onosproject.lldpprovider
@@ -22,5 +23,6 @@ onos-classic:
   - org.onosproject.gui2                 
   - org.opencord.fabric-tofino
   atomix:
+    replicas: 3
     persistence:
       storageClass: fast-disks

--- a/onos-tost/values.yaml
+++ b/onos-tost/values.yaml
@@ -1,0 +1,26 @@
+onos-classic:
+  image: 
+    repository: "onosproject/tost-onos"
+    tag: "1.0.0-b1"
+  apps:
+  - org.onosproject.drivers
+  - org.onosproject.lldpprovider
+  - org.onosproject.route-service
+  - org.onosproject.hostprovider         
+  - org.onosproject.protocols.grpc       
+  - org.onosproject.protocols.gnmi       
+  - org.onosproject.generaldeviceprovider
+  - org.onosproject.protocols.p4runtime  
+  - org.onosproject.p4runtime       
+  - org.onosproject.drivers.p4runtime    
+  - org.onosproject.pipelines.basic      
+  - org.onosproject.pipelines.fabric     
+  - org.onosproject.mcast                
+  - org.onosproject.portloadbalancer     
+  - org.onosproject.segmentrouting       
+  - org.onosproject.t3                   
+  - org.onosproject.gui2                 
+  - org.opencord.fabric-tofino
+  atomix:
+    persistence:
+      storageClass: fast-disks


### PR DESCRIPTION
As the discussion with @charlesmcchan, we set up a new Helm Chart for the ONOS-TOST and added requirement apps as default values.

Part of atomix is used to specify the storageclass name in Kubernetes and the storageclass provider should be installed in Kubernetes advanced. 