### PR TITLE
[AETHER-424] Push netcfg once ONOS is ready

### DIFF
--- a/onos-tost/Chart.yaml
+++ b/onos-tost/Chart.yaml
@@ -1,10 +1,10 @@
 ---
 apiVersion: v1
 name: onos-tost
-version: 0.1.4
+version: 0.1.5
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.3
-description: ONOS TOST
+description: ONOS helm chart for TOST
 keywords:
 - onos
 - sdn

--- a/onos-tost/requirements.yaml
+++ b/onos-tost/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
 - name: onos-classic
-  version: 0.1.3
+  version: 0.1.4
   repository: https://charts.onosproject.org

--- a/onos-tost/templates/netcfg.yaml
+++ b/onos-tost/templates/netcfg.yaml
@@ -1,0 +1,80 @@
+
+{{ $netcfgDir := "/netcfg" }}
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netcfg
+spec:
+  initContainers:
+    # Wait for ONOS to be fully ready
+    - name: debug
+      image: opennetworking/utils:bash-curl-jq
+      env:
+        - name: USER
+          valueFrom:
+            secretKeyRef:
+              name: onos-secret
+              key: username
+        - name: PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: onos-secret
+              key: password
+        - name: URL
+          value: {{ .Values.onos.clusterUrl }}
+        - name: INSTANCES
+          # Need this to get around hyphenated name
+          value: {{ index .Values "onos-classic" "replicas" | quote }}
+      command: ["sh", "-c", "until [ $(curl -s $URL -u $USER:$PASSWD | jq '.nodes | .[] | .status' | grep -c READY) -eq $INSTANCES ]; do echo 'Waiting for ONOS'; sleep 5; done;" ]
+    # Pull netcfg from the git repository
+    - name: netcfg-getter
+      image: alpine/git
+      env:
+        - name: USER
+          valueFrom:
+            secretKeyRef:
+              name: git-secret
+              key: username
+        - name: PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: git-secret
+              key: password
+        - name: GIT_SERVER
+          value: {{ .Values.git.server }}
+        - name: GIT_REPO
+          value: {{ .Values.git.repo }}
+      workingDir: {{ $netcfgDir }}
+      command: ["sh", "-c", "git clone https://$USER:$PASSWD@$GIT_SERVER/$GIT_REPO"]
+      volumeMounts:
+        - name: workdir
+          mountPath: {{ $netcfgDir }}
+  containers:
+    # Push netcfg to ONOS REST API
+    - name: netcfg-setter
+      image: curlimages/curl
+      env:
+        - name: USER
+          valueFrom:
+            secretKeyRef:
+              name: onos-secret
+              key: username
+        - name: PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: onos-secret
+              key: password
+        - name: NETCFG_URL
+          value: {{ .Values.onos.netcfgUrl }}
+        - name: NETCFG_FILE
+          value: {{ .Values.git.file }}
+      workingDir: {{ printf "%s/%s" $netcfgDir .Values.git.repo }}
+      command: ["sh", "-c", "curl -v -u $USER:$PASSWD POST -H 'Content-Type: application/json' $NETCFG_URL -d@$NETCFG_FILE"]
+      volumeMounts:
+        - name: workdir
+          mountPath: {{ $netcfgDir }}
+  volumes:
+  - name: workdir
+    emptyDir: {}
+  restartPolicy: Never

--- a/onos-tost/values.yaml
+++ b/onos-tost/values.yaml
@@ -1,7 +1,7 @@
 onos-classic:
-  image: 
+  image:
     repository: "onosproject/tost-onos"
-    tag: "1.0.0-b1"
+    tag: "1.0.0-b3"
   replicas: 3
   ports:
     - name: up4
@@ -13,25 +13,32 @@ onos-classic:
     - name: ui
       port: 8181
   apps:
-  - org.onosproject.drivers
-  - org.onosproject.lldpprovider
-  - org.onosproject.route-service
-  - org.onosproject.hostprovider         
-  - org.onosproject.protocols.grpc       
-  - org.onosproject.protocols.gnmi       
-  - org.onosproject.generaldeviceprovider
-  - org.onosproject.protocols.p4runtime  
-  - org.onosproject.p4runtime       
-  - org.onosproject.drivers.p4runtime    
-  - org.onosproject.pipelines.basic      
-  - org.onosproject.pipelines.fabric     
-  - org.onosproject.mcast                
-  - org.onosproject.portloadbalancer     
-  - org.onosproject.segmentrouting       
-  - org.onosproject.t3                   
-  - org.onosproject.gui2                 
-  - org.opencord.fabric-tofino
+    - org.onosproject.drivers
+    - org.onosproject.lldpprovider
+    - org.onosproject.route-service
+    - org.onosproject.hostprovider
+    - org.onosproject.protocols.grpc
+    - org.onosproject.protocols.gnmi
+    - org.onosproject.generaldeviceprovider
+    - org.onosproject.protocols.p4runtime
+    - org.onosproject.p4runtime
+    - org.onosproject.drivers.p4runtime
+    - org.onosproject.pipelines.basic
+    - org.onosproject.pipelines.fabric
+    - org.onosproject.mcast
+    - org.onosproject.portloadbalancer
+    - org.onosproject.segmentrouting
+    - org.onosproject.t3
+    - org.onosproject.gui2
+    - org.opencord.fabric-tofino
   atomix:
     replicas: 3
     persistence:
       storageClass: fast-disks
+git:
+  server: "gerrit.opencord.org"
+  repo: "aether-pod-configs"
+  file: "deployment-configs/aether/apps/menlo-prd/onos-netcfg.json"
+onos:
+  netcfgUrl: "http://onos-tost-onos-classic-hs.onos-tost.svc:8181/onos/v1/network/configuration"
+  clusterUrl: "http://onos-tost-onos-classic-hs.onos-tost.svc:8181/onos/v1/cluster"


### PR DESCRIPTION
Get netcfg from pod config repo and push it to ONOS automatically once ONOS starts.
This is a one-time task and will only be retriggered during ONOS helm reinstallation.