### PR TITLE
Fixes to helm chart integration tests when using published charts

### DIFF
--- a/onos-config/tests/onos-config.go
+++ b/onos-config/tests/onos-config.go
@@ -38,12 +38,12 @@ func (s *ONOSConfigSuite) TestInstall(t *testing.T) {
 		Set("scope", "Namespace")
 	assert.NoError(t, raft.Install(true))
 
-	topo := helm.Chart("onos-topo").
+	topo := helm.Chart("onos-topo", "https://charts.onosproject.org").
 		Release("onos-topo").
 		Set("store.controller", "onos-config-atomix-atomix-controller:5679")
 	assert.NoError(t, topo.Install(false))
 
-	config := helm.Chart("onos-config").
+	config := helm.Chart("onos-config", "https://charts.onosproject.org").
 		Release("onos-config").
 		Set("store.controller", "onos-config-atomix-atomix-controller:5679")
 	assert.NoError(t, config.Install(true))

--- a/onos-topo/tests/onos-topo.go
+++ b/onos-topo/tests/onos-topo.go
@@ -38,7 +38,7 @@ func (s *ONOSTopoSuite) TestInstall(t *testing.T) {
 		Set("scope", "Namespace")
 	assert.NoError(t, raft.Install(true))
 
-	topo := helm.Chart("onos-topo").
+	topo := helm.Chart("onos-topo", "https://charts.onosproject.org").
 		Release("onos-topo").
 		Set("store.controller", "onos-topo-atomix-atomix-controller:5679")
 	assert.NoError(t, topo.Install(true))

--- a/onos-umbrella/tests/onos-umbrella.go
+++ b/onos-umbrella/tests/onos-umbrella.go
@@ -38,7 +38,7 @@ func (s *OnosUmbrellaSuite) TestInstall(t *testing.T) {
 		Set("scope", "Namespace")
 	assert.NoError(t, raft.Install(true))
 
-	onos := helm.Chart("onos-umbrella").
+	onos := helm.Chart("onos-umbrella", "https://charts.onosproject.org").
 		Release("onos-umbrella").
 		Set("global.store.controller", "onos-umbrella-atomix-atomix-controller:5679").
 		Set("import.onos-gui.enabled", false).


### PR DESCRIPTION
This PR implements running the ONOS chart integration tests against the published charts by adding repo URLs to the chart references.