### PR TITLE
Add startup probe to onos-config chart

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: onos-config
-version: 0.0.10
+version: 0.0.11
 kubeVersion: ">=1.17.0"
 appVersion: v0.6.10
 description: ONOS Config Manager

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -80,15 +80,20 @@ spec:
               containerPort: 40000
               protocol: TCP
             {{- end }}
+          startupProbe:
+            tcpSocket:
+              port: 5150
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 10
+            periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 15
-            periodSeconds: 20
-          readinessProbe:
-            tcpSocket:
-                port: 5150
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
             periodSeconds: 10
           volumeMounts:
             - name: config


### PR DESCRIPTION
Adds a startup probe to prevent restarts while waiting for dependencies during slow startup.