### PR TITLE
Add startup probe to onos-topo chart

### DIFF
--- a/onos-topo/Chart.yaml
+++ b/onos-topo/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-topo
 description: ONOS Topology service
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: v0.6.15
 keywords:
   - onos

--- a/onos-topo/templates/deployment.yaml
+++ b/onos-topo/templates/deployment.yaml
@@ -70,15 +70,20 @@ spec:
               containerPort: 40000
               protocol: TCP
             {{- end }}
-          livenessProbe:
+          startupProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            periodSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 10
             periodSeconds: 10
           volumeMounts:
             - name: config


### PR DESCRIPTION
Adds a startup probe to prevent restarts while waiting for dependencies during slow startup.