### PR TITLE
Support custom log4j2 config and annotations via helm value

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.6
+version: 0.1.7
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.4
 description: ONOS cluster

--- a/onos-classic/templates/_helpers.tpl
+++ b/onos-classic/templates/_helpers.tpl
@@ -18,3 +18,7 @@ We truncate at 60 chars because some Kubernetes name fields are limited to 63 (b
 {{- define "atomix.fullname" -}}
 {{- printf "%s-%s" .Release.Name "atomix" | trunc 59 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "onos-apps" -}}
+{{- join "," . -}}
+{{- end -}}

--- a/onos-classic/templates/configmap-logging.yaml
+++ b/onos-classic/templates/configmap-logging.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.logging }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-logging
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  org.ops4j.pax.logging.cfg: |
+    {{- .Values.logging.config  | nindent 4 }}
+{{- end }}

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -108,6 +108,11 @@ spec:
           - name: config
             mountPath: /root/onos/config/cluster.json
             subPath: cluster.json
+          {{- if .Values.logging }}
+          - name: logging
+            mountPath: /root/onos/apache-karaf-{{ .Values.logging.karafVersion }}/etc/org.ops4j.pax.logging.cfg
+            subPath: org.ops4j.pax.logging.cfg
+          {{- end}}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}
@@ -125,3 +130,11 @@ spec:
             defaultMode: 0744
         - name: config
           emptyDir: {}
+        {{- if .Values.logging }}
+        - name: logging
+          configMap:
+            name: {{ template "fullname" . }}-logging
+            items:
+              - key: org.ops4j.pax.logging.cfg
+                path: org.ops4j.pax.logging.cfg
+        {{- end}}

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -29,6 +29,10 @@ spec:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.podAntiAffinity.enabled }}
       affinity:

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -71,6 +71,11 @@ spec:
         env:
           - name: JAVA_OPTS
             value: -Xmx{{ .Values.heap }}
+          {{- with .Values.apps }}
+          - name: ONOS_APPS
+            value: {{ template "onos-apps" . }}
+          {{- end }}
+
         {{- with .Values.ports }}
         ports:
         {{- range . }}
@@ -103,11 +108,6 @@ spec:
           - name: config
             mountPath: /root/onos/config/cluster.json
             subPath: cluster.json
-          {{- range .Values.apps }}
-          - name: config
-            mountPath: /root/onos/apps/{{ . }}/active
-            subPath: active
-          {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -39,3 +39,16 @@ ports:
     port: 8101
   - name: ui
     port: 8181
+
+# logging:
+#   karafVersion: 4.2.9
+#   config: |
+#     # Just an example. See org.ops4j.pax.logging.cfg for details.
+#
+#     log4j2.rootLogger.level = DEBUG
+#
+#     log4j2.rootLogger.appenderRef.Console.ref = Console
+#     log4j2.appender.console.type = Console
+#     log4j2.appender.console.name = Console
+#     log4j2.appender.console.layout.type = PatternLayout
+#     log4j2.appender.console.layout.pattern = %d{RFC3339} %-5level [%c{1}] %msg%n%throwable


### PR DESCRIPTION
Additionally, respect ONOS_APPS to avoid `gui2` being enabled by default