### PR TITLE
Move onos-config model plugins to initContainers

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: onos-config
-version: 0.0.14
+version: 0.0.15
 kubeVersion: ">=1.17.0"
 appVersion: v0.6.12
 description: ONOS Config Manager

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -34,6 +34,21 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        # Load model plugins as side car containers
+        {{- range $key, $plugin := .Values.plugins }}
+        - name: {{ printf "config-model-%s-%s" $plugin.name $plugin.version | replace "." "-" }}
+          image: {{ printf "%s:%s" $plugin.image.repository $plugin.image.tag }}
+          imagePullPolicy: {{ $plugin.image.pullPolicy }}
+          command:
+            - "/copylibandstay"
+          args:
+            - {{ printf "%s.so.%s" $plugin.name $plugin.version }}
+            - {{ printf "/usr/local/lib/%s.so.%s" $plugin.name $plugin.version }}
+          volumeMounts:
+            - name: shared-data
+              mountPath: /usr/local/lib
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -109,21 +124,6 @@ spec:
               add:
                 - SYS_PTRACE
             {{- end }}
-        # Load model plugins as side car containers
-        {{- range $key, $plugin := .Values.plugins }}
-        - name: {{ printf "config-model-%s-%s" $plugin.name $plugin.version | replace "." "-" }}
-          image: {{ printf "%s:%s" $plugin.image.repository $plugin.image.tag }}
-          imagePullPolicy: {{ $plugin.image.pullPolicy }}
-          command:
-            - "/copylibandstay"
-          args:
-            - {{ printf "%s.so.%s" $plugin.name $plugin.version }}
-            - {{ printf "/usr/local/lib/%s.so.%s" $plugin.name $plugin.version }}
-            - "stayrunning"
-          volumeMounts:
-            - name: shared-data
-              mountPath: /usr/local/lib
-          {{- end }}
       # Mount volumes
       volumes:
         - name: config

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       initContainers:
-        # Load model plugins as side car containers
+        # Run model plugins as init containers to load plugins onto the shared volume
         {{- range $key, $plugin := .Values.plugins }}
         - name: {{ printf "config-model-%s-%s" $plugin.name $plugin.version | replace "." "-" }}
           image: {{ printf "%s:%s" $plugin.image.repository $plugin.image.tag }}


### PR DESCRIPTION
This PR fixes a race condition in the startup of the onos-config service. If the `onos-config` container starts before model plugin containers have run, plugins may not yet have been migrated to the shared volume and onos-config startup will fail:

```
2020-09-01T22:28:36.786Z	FATAL	main	onos-config/onos-config.go:188	Unable to start onos-config plugin.Open("/usr/local/lib/shared/e2node.so.1.0.0"): realpath failed
github.com/onosproject/onos-lib-go/pkg/logging.(*zapOutput).Fatal
	/go/src/github.com/onosproject/onos-config/vendor/github.com/onosproject/onos-lib-go/pkg/logging/output.go:204
github.com/onosproject/onos-lib-go/pkg/logging.(*zapLogger).Fatal
	/go/src/github.com/onosproject/onos-config/vendor/github.com/onosproject/onos-lib-go/pkg/logging/logger.go:292
main.main
	/go/src/github.com/onosproject/onos-config/cmd/onos-config/onos-config.go:188
runtime.main
	/usr/local/go/src/runtime/proc.go:203
```

I suspect model plugin containers are more suitable to be run as `initContainers` to ensure they've completed before the main onos-config container starts. Additionally, this allows the model plugin containers to exit rather than running and doing nothing.