### PR TITLE
Passing java_opts as parameter from values.yaml

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.9
+version: 0.1.10
 kubeVersion: ">=1.10.0"
-appVersion: 2.2.4
+appVersion: 2.2.6
 description: ONOS cluster
 keywords:
 - onos

--- a/onos-classic/requirements.yaml
+++ b/onos-classic/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
 - name: atomix
-  version: 0.1.3
+  version: 0.1.4
   repository: https://charts.atomix.io

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
             cpu: {{ .Values.resources.requests.cpu }}
         env:
           - name: JAVA_OPTS
-            value: -Xmx{{ .Values.heap }}
+            value: {{ .Values.java_opts }}
           {{- with .Values.apps }}
           - name: ONOS_APPS
             value: {{ template "onos-apps" . }}

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -8,7 +8,7 @@ image:
   pullSecrets: []
 
 replicas: 3
-heap: 4G
+java_opts: -Xmx4G
 apps:
 - org.onosproject.openflow-base
 


### PR DESCRIPTION
This change allows passing of java_opts environment variable to the container through the values files, allowing for easy tuning of java parameters that ONOS uses to run