### PR TITLE
Add support for private Docker registries to onos-topo chart

### DIFF
--- a/onos-topo/Chart.yaml
+++ b/onos-topo/Chart.yaml
@@ -3,8 +3,8 @@ name: onos-topo
 description: ONOS Topology service
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.14
-appVersion: v0.6.17
+version: 0.0.15
+appVersion: v0.6.19
 keywords:
   - onos
   - sdn

--- a/onos-topo/templates/_helpers.tpl
+++ b/onos-topo/templates/_helpers.tpl
@@ -56,9 +56,9 @@ onos-topo image name
 */}}
 {{- define "onos-topo.imagename" -}}
 {{- if .Values.global.image.registry -}}
-{{- .Values.global.image.registry -}}/
+{{- printf "%s/" .Values.global.image.registry -}}
 {{- else if .Values.image.registry -}}
-{{- .Values.image.registry -}}/
+{{- printf "%s/" .Values.image.registry -}}
 {{- end -}}
 {{- printf "%s:" .Values.image.repository -}}
 {{- if .Values.global.image.tag -}}

--- a/onos-topo/templates/_helpers.tpl
+++ b/onos-topo/templates/_helpers.tpl
@@ -50,3 +50,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "onos-topo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+onos-topo image name
+*/}}
+{{- define "onos-topo.image-name" -}}
+{{- if .Values.global.image.registry -}}
+{{- .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/onos-topo/templates/_helpers.tpl
+++ b/onos-topo/templates/_helpers.tpl
@@ -56,9 +56,9 @@ onos-topo image name
 */}}
 {{- define "onos-topo.imagename" -}}
 {{- if .Values.global.image.registry -}}
-{{- .Values.global.image.registry -}}
+{{- .Values.global.image.registry -}}/
 {{- else if .Values.image.registry -}}
-{{- .Values.image.registry -}}
+{{- .Values.image.registry -}}/
 {{- end -}}
 {{- printf "%s:" .Values.image.repository -}}
 {{- if .Values.global.image.tag -}}

--- a/onos-topo/templates/_helpers.tpl
+++ b/onos-topo/templates/_helpers.tpl
@@ -54,7 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 onos-topo image name
 */}}
-{{- define "onos-topo.image-name" -}}
+{{- define "onos-topo.imagename" -}}
 {{- if .Values.global.image.registry -}}
 {{- .Values.global.image.registry -}}
 {{- else if .Values.image.registry -}}

--- a/onos-topo/templates/database.yaml
+++ b/onos-topo/templates/database.yaml
@@ -34,7 +34,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default .Values.storage.consensus.image "atomix/raft-storage-node:v0.2.0" }}
+  image: {{ default .Values.storage.consensus.image "atomix/raft-storage-node:v0.4.0" }}
   imagePullPolicy: {{ .Values.storage.consensus.imagePullPolicy }}
   replicas: {{ .Values.storage.consensus.replicas }}
   partitionsPerCluster: {{ .Values.storage.consensus.partitionsPerCluster }}
@@ -49,7 +49,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default .Values.storage.consensus.image "atomix/cache-storage-node:v0.2.0" }}
+  image: {{ default .Values.storage.consensus.image "atomix/cache-storage-node:v0.4.0" }}
   imagePullPolicy: {{ .Values.storage.consensus.imagePullPolicy }}
 {{- else }}
 {{ fail ( printf "%s is not a valid storage type" .Values.storage.consensus.type ) }}

--- a/onos-topo/templates/deployment.yaml
+++ b/onos-topo/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "onos-topo.image-name" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             # *_NAMESPACE and *_NAME environment variables are recognized by onos-lib-go utilities.

--- a/onos-topo/templates/deployment.yaml
+++ b/onos-topo/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ include "onos-topo.image-name" . | quote }}
+          image: {{ include "onos-topo.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             # *_NAMESPACE and *_NAME environment variables are recognized by onos-lib-go utilities.

--- a/onos-topo/values.yaml
+++ b/onos-topo/values.yaml
@@ -3,6 +3,9 @@
 # Declare variables to be passed into your templates.
 
 global:
+  image:
+    registry: ""
+    tag: ""
   storage:
     controller: ""
     config:

--- a/onos-topo/values.yaml
+++ b/onos-topo/values.yaml
@@ -11,8 +11,9 @@ global:
 replicaCount: 1
 
 image:
+  registry: ""
   repository: onosproject/onos-topo
-  tag: v0.6.17
+  tag: v0.6.19
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
This PR adds an `image.registry` value to the onos-topo chart which optionally prefixes a Docker registry on image names. Additionally, it upgrades the default Atomix images used.