### PR TITLE
Add support for private Docker registries to onos-config chart

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: onos-config
-version: 0.0.17
+version: 0.0.18
 kubeVersion: ">=1.17.0"
-appVersion: v0.6.14
+appVersion: v0.6.16
 description: ONOS Config Manager
 keywords:
   - onos

--- a/onos-config/templates/_helpers.tpl
+++ b/onos-config/templates/_helpers.tpl
@@ -51,3 +51,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "onos-config.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+onos-config image name
+*/}}
+{{- define "onos-config.image-name" -}}
+{{- if .Values.global.image.registry -}}
+{{- .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- .Values.image.tag -}}
+{{- end -}}
+{{- end -}}

--- a/onos-config/templates/_helpers.tpl
+++ b/onos-config/templates/_helpers.tpl
@@ -57,9 +57,9 @@ onos-config image name
 */}}
 {{- define "onos-config.imagename" -}}
 {{- if .Values.global.image.registry -}}
-{{- .Values.global.image.registry -}}/
+{{- printf "%s/" .Values.global.image.registry -}}
 {{- else if .Values.image.registry -}}
-{{- .Values.image.registry -}}/
+{{- printf "%s/" .Values.image.registry -}}
 {{- end -}}
 {{- printf "%s:" .Values.image.repository -}}
 {{- if .Values.global.image.tag -}}

--- a/onos-config/templates/_helpers.tpl
+++ b/onos-config/templates/_helpers.tpl
@@ -57,9 +57,9 @@ onos-config image name
 */}}
 {{- define "onos-config.imagename" -}}
 {{- if .Values.global.image.registry -}}
-{{- .Values.global.image.registry -}}
+{{- .Values.global.image.registry -}}/
 {{- else if .Values.image.registry -}}
-{{- .Values.image.registry -}}
+{{- .Values.image.registry -}}/
 {{- end -}}
 {{- printf "%s:" .Values.image.repository -}}
 {{- if .Values.global.image.tag -}}

--- a/onos-config/templates/_helpers.tpl
+++ b/onos-config/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/*
 onos-config image name
 */}}
-{{- define "onos-config.image-name" -}}
+{{- define "onos-config.imagename" -}}
 {{- if .Values.global.image.registry -}}
 {{- .Values.global.image.registry -}}
 {{- else if .Values.image.registry -}}

--- a/onos-config/templates/database.yaml
+++ b/onos-config/templates/database.yaml
@@ -34,7 +34,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default .Values.storage.consensus.image "atomix/raft-storage-node:v0.2.0" }}
+  image: {{ default .Values.storage.consensus.image "atomix/raft-storage-node:v0.4.0" }}
   imagePullPolicy: {{ .Values.storage.consensus.imagePullPolicy }}
   replicas: {{ .Values.storage.consensus.replicas }}
   partitionsPerCluster: {{ .Values.storage.consensus.partitionsPerCluster }}
@@ -49,7 +49,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default .Values.storage.consensus.image "atomix/cache-storage-node:v0.2.0" }}
+  image: {{ default .Values.storage.consensus.image "atomix/cache-storage-node:v0.4.0" }}
   imagePullPolicy: {{ .Values.storage.consensus.imagePullPolicy }}
 {{- else }}
 {{ fail ( printf "%s is not a valid storage type" .Values.storage.consensus.type ) }}

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "onos-topo.image-name" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             # *_NAMESPACE and *_NAME environment variables are recognized by onos-lib-go utilities.

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ include "onos-topo.image-name" . | quote }}
+          image: {{ include "onos-config.imagename" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             # *_NAMESPACE and *_NAME environment variables are recognized by onos-lib-go utilities.

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -3,6 +3,9 @@
 # Declare variables to be passed into your templates.
 
 global:
+  image:
+    registry: ""
+    tag: ""
   storage:
     controller: ""
     config:

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -11,8 +11,9 @@ global:
 replicaCount: 1
 
 image:
+  registry: ""
   repository: onosproject/onos-config
-  tag: v0.6.14
+  tag: v0.6.16
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
This PR adds an `image.registry` value to the onos-topo chart which optionally prefixes a Docker registry on image names. Additionally, it upgrades the default Atomix images used.