### PR TITLE
[AETHER-939] Fix readiness/liveness probes

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.10
+version: 0.1.11
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.6
 description: ONOS cluster

--- a/onos-classic/templates/configmap-probe.yaml
+++ b/onos-classic/templates/configmap-probe.yaml
@@ -11,9 +11,10 @@ metadata:
 data:
   check-onos-status: |
     #!/bin/bash
-    set -e
+
+    # Wait for {{ .Values.probe_timeout }}s before timing out
     host=$(hostname -s)
-    result=$(curl -s -f http://$host:8181/onos/v1/cluster/$host --user onos:rocks)
+    result=$(curl -m {{ .Values.probe_timeout }} -s -f http://$host:8181/onos/v1/cluster/$host --user onos:rocks)
     echo $result
 
     if ! printf '%q' $result | grep -q -i "READY"; then
@@ -27,7 +28,7 @@ data:
     {{- end }}
 
     for app in ${apps[@]}; do
-      result=$(curl -s -f http://$host:8181/onos/v1/applications/$app/health --user onos:rocks)
+      result=$(curl -m {{ .Values.probe_timeout }} -s -f http://$host:8181/onos/v1/applications/$app/health --user onos:rocks)
       echo $result
       if ! printf %q $result | grep -q -i "READY"; then
         echo "$app is not yet ready"

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -110,6 +110,10 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 15
           failureThreshold: 10
+          # Workaround for the probes issue - https://github.com/kubernetes/kubernetes/issues/82987
+          # we use in curl a timeout lower than this to avoid the deadline exceed. Also we dont't
+          # allow the script to exit immeditately.
+          timeoutSeconds: {{ mul .Values.probe_timeout 2 }}
         livenessProbe:
           exec:
             command:
@@ -118,7 +122,7 @@ spec:
               - /root/onos/bin/check-onos-status
           initialDelaySeconds: 300
           periodSeconds: 15
-          timeoutSeconds: 5
+          timeoutSeconds: {{ mul .Values.probe_timeout 2 }}
         volumeMounts:
           - name: probe-scripts
             mountPath: /root/onos/bin/check-onos-status

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -9,6 +9,7 @@ image:
 
 replicas: 3
 java_opts: -Xmx4G
+probe_timeout: 5
 apps:
 - org.onosproject.openflow-base
 


### PR DESCRIPTION
- Defines a value for the timeout
- To avoid the issue 82987 in k8s sets the timeout doubling this value
- Do not allow check-onos-status to exit immediately
- Sets a timeout for curl equals to the timeout value
- Updates chart version