### PR TITLE
Few optimizations for ONOS clustered mode

### DIFF
--- a/onos-tost/Chart.yaml
+++ b/onos-tost/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-tost
-version: 0.1.22
+version: 0.1.23
 kubeVersion: ">=1.10.0"
 appVersion: 1.0.2-b4
 description: ONOS helm chart for TOST

--- a/onos-tost/templates/configmap-config.yaml
+++ b/onos-tost/templates/configmap-config.yaml
@@ -32,9 +32,10 @@ data:
         cp $REMOTE_CHASSIS_CONFIG $LOCAL_CHASSIS_CONFIG
     fi
   wait-onos: |
-   #!/bin/sh
+    #!/bin/sh
     set -e -x
-    until [ 0 -ne $(kubectl -n $NAMESPACE get --no-headers pods -lapp=$APP_LABEL | wc -l) ]; do
+    replicas=$(kubectl -n $NAMESPACE get --no-headers sts -lapp=$APP_LABEL -o custom-columns=':.spec.replicas')
+    until [ $replicas -eq $(kubectl -n $NAMESPACE get --no-headers pods -lapp=$APP_LABEL | grep Running | wc -l) ]; do
     echo 'Waiting for ONOS POD running';
     sleep 5;
     done

--- a/onos-tost/templates/serviceaccount.yaml
+++ b/onos-tost/templates/serviceaccount.yaml
@@ -15,6 +15,12 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/onos-tost/values.yaml
+++ b/onos-tost/values.yaml
@@ -26,7 +26,6 @@ onos-classic:
     - org.onosproject.netcfghostprovider
     - org.onosproject.gui
     - org.onosproject.drivers.barefoot
-    - org.opencord.fabric-tofino
     - org.onosproject.segmentrouting
     - org.onosproject.t3
     - org.omecproject.up4
@@ -70,7 +69,7 @@ onos-classic:
   atomix:
     replicas: 3
     persistence:
-      storageClass: fast-disks
+      enabled: false
   app_label: onos-tost-onos-classic
 
 service_account_name: internal-kubectl


### PR DESCRIPTION
- Disable persistent volume for Atomix
  We don't expect all ONOS instance going down simulteneously.
  Having PV enabled doesn't provide much value under that assumption and it is known to slow down the system.
- Fixed an issue where config pusher doesn't properly wait for ONOS ready.
- Disable fabric-tofino app since we only use fabric-tna now