### PR TITLE
Add Helm chart for onos-operator with config/topo controllers

### DIFF
--- a/onos-operator/.helmignore
+++ b/onos-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/onos-operator/Chart.yaml
+++ b/onos-operator/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: onos-operator
+version: 0.1.0
+kubeVersion: ">=1.17.0"
+appVersion: v0.1.0
+description: µONOS Operator
+keywords:
+  - onos
+  - sdn
+home: https://onosproject.org
+maintainers:
+  - name: ONOS Support
+    email: support@opennetworking.org

--- a/onos-operator/charts/config-operator/Chart.yaml
+++ b/onos-operator/charts/config-operator/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: config-operator
+version: 0.1.0
+kubeVersion: ">=1.17.0"
+appVersion: v0.1.0
+description: µONOS Config Operator
+keywords:
+  - onos
+  - sdn
+home: https://onosproject.org
+maintainers:
+  - name: ONOS Support
+    email: support@opennetworking.org

--- a/onos-operator/charts/config-operator/crds/model.yaml
+++ b/onos-operator/charts/config-operator/crds/model.yaml
@@ -1,0 +1,77 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: models.config.onosproject.org
+spec:
+  group: config.onosproject.org
+  scope: Namespaced
+  names:
+    kind: Model
+    listKind: ModelList
+    plural: models
+    singular: model
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              properties:
+                plugin:
+                  type: object
+                  required:
+                    - type
+                    - version
+                  properties:
+                    type:
+                      type: string
+                    version:
+                      type: string
+                dependencies:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                modules:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - version
+                      - data
+                    properties:
+                      name:
+                        type: string
+                      organization:
+                        type: string
+                      version:
+                        type: string
+                      data:
+                        type: string
+            status:
+              type: object
+              properties:
+                registryStatuses:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      podName:
+                        type: string
+                      phase:
+                        type: string

--- a/onos-operator/charts/config-operator/crds/model.yaml
+++ b/onos-operator/charts/config-operator/crds/model.yaml
@@ -11,67 +11,67 @@ spec:
     plural: models
     singular: model
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          required:
-            - spec
-          properties:
-            spec:
-              type: object
-              properties:
-                plugin:
+  - name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            properties:
+              plugin:
+                type: object
+                required:
+                - type
+                - version
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+              dependencies:
+                type: array
+                items:
                   type: object
                   required:
-                    - type
-                    - version
+                  - name
                   properties:
-                    type:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+              modules:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - name
+                  - version
+                  - data
+                  properties:
+                    name:
+                      type: string
+                    organization:
                       type: string
                     version:
                       type: string
-                dependencies:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - name
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                modules:
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - name
-                      - version
-                      - data
-                    properties:
-                      name:
-                        type: string
-                      organization:
-                        type: string
-                      version:
-                        type: string
-                      data:
-                        type: string
-            status:
-              type: object
-              properties:
-                registryStatuses:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      podName:
-                        type: string
-                      phase:
-                        type: string
+                    data:
+                      type: string
+          status:
+            type: object
+            properties:
+              registryStatuses:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    podName:
+                      type: string
+                    phase:
+                      type: string

--- a/onos-operator/charts/config-operator/crds/modelregistry.yaml
+++ b/onos-operator/charts/config-operator/crds/modelregistry.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: modelregistries.config.onosproject.org
+spec:
+  group: config.onosproject.org
+  scope: Namespaced
+  names:
+    kind: ModelRegistry
+    listKind: ModelRegistryList
+    plural: modelregistries
+    singular: modelregistry
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              properties:
+                volume:
+                  x-kubernetes-preserve-unknown-fields: true
+                  type: object

--- a/onos-operator/charts/config-operator/crds/modelregistry.yaml
+++ b/onos-operator/charts/config-operator/crds/modelregistry.yaml
@@ -11,18 +11,18 @@ spec:
     plural: modelregistries
     singular: modelregistry
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      schema:
-        openAPIV3Schema:
-          type: object
-          required:
-            - spec
-          properties:
-            spec:
-              type: object
-              properties:
-                volume:
-                  x-kubernetes-preserve-unknown-fields: true
-                  type: object
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - spec
+        properties:
+          spec:
+            type: object
+            properties:
+              cache:
+                x-kubernetes-preserve-unknown-fields: true
+                type: object

--- a/onos-operator/charts/config-operator/templates/_helpers.tpl
+++ b/onos-operator/charts/config-operator/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "config-operator.name" -}}
+{{ include "onos-operator.name" . }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "config-operator.fullname" -}}
+{{ include "onos-operator.fullname" . }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "config-operator.chart" -}}
+{{ include "onos-operator.chart" . }}
+{{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "config-operator.labels" -}}
+{{ include "onos-operator.labels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "config-operator.selectorLabels" -}}
+{{ include "onos-operator.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+config-operator image name
+*/}}
+{{- define "config-operator.imagename" -}}
+{{ include "onos-operator.imagename" . }}
+{{- end -}}
+
+{{/*
+config-operator scope
+*/}}
+{{- define "config-operator.scope" -}}
+{{ include "onos-operator.scope" . }}
+{{- end -}}

--- a/onos-operator/charts/config-operator/templates/clusterrole.yaml
+++ b/onos-operator/charts/config-operator/templates/clusterrole.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: {{ template "config-operator.fullname" . }}
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  {{- $scope := include "config-operator.scope" . }}
+  {{- if eq $scope "cluster" }}
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - config.onosproject.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  {{- end }}
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - '*'

--- a/onos-operator/charts/config-operator/templates/clusterrolebinding.yaml
+++ b/onos-operator/charts/config-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "config-operator.fullname" . }}
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "config-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "config-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/onos-operator/charts/config-operator/templates/configmap.yaml
+++ b/onos-operator/charts/config-operator/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "config-operator.fullname" . }}-config
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  logging.yaml: |-
+{{ toYaml .Values.logging | indent 4 }}

--- a/onos-operator/charts/config-operator/templates/deployment.yaml
+++ b/onos-operator/charts/config-operator/templates/deployment.yaml
@@ -1,0 +1,108 @@
+{{- $scope := include "config-operator.scope" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "config-operator.fullname" . }}
+  namespace: {{ .Release.Namespace | default "kube-system" }}
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      name: {{ template "config-operator.fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "config-operator.fullname" . }}
+    spec:
+      serviceAccountName: {{ template "config-operator.fullname" . }}
+      initContainers:
+        - name: init-certs
+          image: onosproject/config-operator-init:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+          env:
+            - name: CONTROLLER_NAME
+              value: {{ template "config-operator.fullname" . }}
+            - name: CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_SCOPE
+              value: {{ $scope }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: config
+              mountPath: /etc/onos/config
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/onos/plugins
+            - name: certs
+              mountPath: /etc/webhook/certs
+      containers:
+        - name: controller
+          image: onosproject/config-operator:latest
+          ports:
+            - containerPort: 60000
+              name: metrics
+            - containerPort: 443
+              name: webhook-server
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/onos-operator-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: CONTROLLER_NAME
+              value: {{ template "config-operator.fullname" . }}
+            - name: CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_SCOPE
+              value: {{ $scope }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: config
+              mountPath: /etc/onos/config
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/onos/plugins
+            - name: certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "config-operator.fullname" . }}-config
+        - name: certs
+          emptyDir: {}
+        - name: plugins
+          emptyDir: {}

--- a/onos-operator/charts/config-operator/templates/mutatingwebhook.yaml
+++ b/onos-operator/charts/config-operator/templates/mutatingwebhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "config-operator.fullname" . }}
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+webhooks:
+- name: registry.config.onosproject.org
+  rules:
+  - operations: ["CREATE"]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    scope: Namespaced
+  clientConfig:
+    service:
+      name: {{ template "config-operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /registry
+  admissionReviewVersions: ["v1beta1"]
+  sideEffects: None
+  failurePolicy: Ignore
+  timeoutSeconds: 10

--- a/onos-operator/charts/config-operator/templates/role.yaml
+++ b/onos-operator/charts/config-operator/templates/role.yaml
@@ -1,0 +1,35 @@
+{{- $scope := include "config-operator.scope" . }}
+{{- if eq $scope "namespace" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ template "config-operator.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - config.onosproject.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+{{- end }}

--- a/onos-operator/charts/config-operator/templates/rolebinding.yaml
+++ b/onos-operator/charts/config-operator/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- $scope := include "config-operator.scope" . }}
+{{- if eq $scope "namespace" }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "config-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "config-operator.fullname" . }}
+roleRef:
+  kind: Role
+  name: {{ template "config-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/onos-operator/charts/config-operator/templates/service.yaml
+++ b/onos-operator/charts/config-operator/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "config-operator.fullname" . }}
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    name: {{ template "config-operator.fullname" . }}
+  ports:
+  - name: webhook
+    port: 443
+    targetPort: 443

--- a/onos-operator/charts/config-operator/templates/serviceaccount.yaml
+++ b/onos-operator/charts/config-operator/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "config-operator.fullname" . }}

--- a/onos-operator/charts/config-operator/values.yaml
+++ b/onos-operator/charts/config-operator/values.yaml
@@ -1,0 +1,29 @@
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  scope: ""
+  image:
+    registry: ""
+    tag: ""
+
+scope: Cluster
+replicas: 1
+image:
+  registry: ""
+  repository: onosproject/config-operator
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+logging:
+  loggers:
+    root:
+      level: info
+      output:
+        stdout:
+          sink: stdout
+  sinks:
+    stdout:
+      type: stdout
+      stdout: {}

--- a/onos-operator/charts/config-operator/values.yaml
+++ b/onos-operator/charts/config-operator/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 image:
   registry: ""
   repository: onosproject/config-operator
-  tag: latest
+  tag: v0.1.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/onos-operator/charts/topo-operator/Chart.yaml
+++ b/onos-operator/charts/topo-operator/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: topo-operator
+version: 0.1.0
+kubeVersion: ">=1.17.0"
+appVersion: v0.1.0
+description: µONOS Topology Operator
+keywords:
+  - onos
+  - sdn
+home: https://onosproject.org
+maintainers:
+  - name: ONOS Support
+    email: support@opennetworking.org

--- a/onos-operator/charts/topo-operator/crds/entity.yaml
+++ b/onos-operator/charts/topo-operator/crds/entity.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: entities.topo.onosproject.org
+spec:
+  group: topo.onosproject.org
+  scope: Namespaced
+  names:
+    kind: Entity
+    listKind: EntityList
+    plural: entities
+    singular: entity
+    shortNames:
+      - ent
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - kind
+              properties:
+                kind:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                attributes:
+                  type: object
+                  additionalProperties:
+                    type: string
+            status:
+              type: object

--- a/onos-operator/charts/topo-operator/crds/kind.yaml
+++ b/onos-operator/charts/topo-operator/crds/kind.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kinds.topo.onosproject.org
+spec:
+  group: topo.onosproject.org
+  scope: Namespaced
+  names:
+    kind: Kind
+    listKind: KindList
+    plural: kinds
+    singular: kind
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                attributes:
+                  type: object
+                  additionalProperties:
+                    type: string
+            status:
+              type: object

--- a/onos-operator/charts/topo-operator/crds/relation.yaml
+++ b/onos-operator/charts/topo-operator/crds/relation.yaml
@@ -1,0 +1,64 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: relations.topo.onosproject.org
+spec:
+  group: topo.onosproject.org
+  scope: Namespaced
+  names:
+    kind: Relation
+    listKind: RelationList
+    plural: relations
+    singular: relation
+    shortNames:
+      - rel
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - kind
+                - source
+                - target
+              properties:
+                kind:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                source:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                target:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                attributes:
+                  type: object
+                  additionalProperties:
+                    type: string
+            status:
+              type: object

--- a/onos-operator/charts/topo-operator/crds/service.yaml
+++ b/onos-operator/charts/topo-operator/crds/service.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.topo.onosproject.org
+spec:
+  group: topo.onosproject.org
+  scope: Namespaced
+  names:
+    kind: Service
+    listKind: ServiceList
+    plural: services
+    singular: service
+    shortNames:
+      - svc
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                selector:
+                  type: object
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+            status:
+              type: object

--- a/onos-operator/charts/topo-operator/templates/_helpers.tpl
+++ b/onos-operator/charts/topo-operator/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "topo-operator.name" -}}
+{{ include "onos-operator.name" . }}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "topo-operator.fullname" -}}
+{{ include "onos-operator.fullname" . }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "topo-operator.chart" -}}
+{{ include "onos-operator.chart" . }}
+{{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "topo-operator.labels" -}}
+{{ include "onos-operator.labels" . }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "topo-operator.selectorLabels" -}}
+{{ include "onos-operator.selectorLabels" . }}
+{{- end -}}
+
+{{/*
+topo-operator image name
+*/}}
+{{- define "topo-operator.imagename" -}}
+{{ include "onos-operator.imagename" . }}
+{{- end -}}
+
+{{/*
+topo-operator scope
+*/}}
+{{- define "topo-operator.scope" -}}
+{{ include "onos-operator.scope" . }}
+{{- end -}}

--- a/onos-operator/charts/topo-operator/templates/clusterrole.yaml
+++ b/onos-operator/charts/topo-operator/templates/clusterrole.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: {{ template "topo-operator.fullname" . }}
+  labels:
+    app: {{ template "topo-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+  {{- $scope := include "topo-operator.scope" . }}
+  {{- if eq $scope "cluster" }}
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - topo.onosproject.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  {{- end }}
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - '*'

--- a/onos-operator/charts/topo-operator/templates/clusterrolebinding.yaml
+++ b/onos-operator/charts/topo-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "config-operator.fullname" . }}
+  labels:
+    app: {{ template "config-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "config-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "config-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/onos-operator/charts/topo-operator/templates/configmap.yaml
+++ b/onos-operator/charts/topo-operator/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "onos-operator.fullname" . }}-config
+  labels:
+    app: {{ template "onos-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  logging.yaml: |-
+{{ toYaml .Values.logging | indent 4 }}

--- a/onos-operator/charts/topo-operator/templates/deployment.yaml
+++ b/onos-operator/charts/topo-operator/templates/deployment.yaml
@@ -1,0 +1,62 @@
+{{- $scope := include "topo-operator.scope" . }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "topo-operator.fullname" . }}
+  namespace: {{ .Release.Namespace | default "kube-system" }}
+  labels:
+    app: {{ template "topo-operator.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      name: {{ template "topo-operator.fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "topo-operator.fullname" . }}
+    spec:
+      serviceAccountName: {{ template "topo-operator.fullname" . }}
+      containers:
+        - name: controller
+          image: onosproject/topo-operator:latest
+          ports:
+            - containerPort: 60000
+              name: metrics
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/onos-operator-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: CONTROLLER_NAME
+              value: {{ template "topo-operator.fullname" . }}
+            - name: CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_SCOPE
+              value: {{ $scope }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: config
+              mountPath: /etc/onos/config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "topo-operator.fullname" . }}-config

--- a/onos-operator/charts/topo-operator/templates/role.yaml
+++ b/onos-operator/charts/topo-operator/templates/role.yaml
@@ -1,0 +1,41 @@
+{{- $scope := include "topo-operator.scope" . }}
+{{- if eq $scope "namespace" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ template "topo-operator.fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - '*'
+  - apiGroups:
+      - topo.onosproject.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - '*'
+{{- end }}

--- a/onos-operator/charts/topo-operator/templates/rolebinding.yaml
+++ b/onos-operator/charts/topo-operator/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+{{- $scope := include "topo-operator.scope" . }}
+{{- if eq $scope "namespace" }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "topo-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "topo-operator.fullname" . }}
+roleRef:
+  kind: Role
+  name: {{ template "topo-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/onos-operator/charts/topo-operator/templates/serviceaccount.yaml
+++ b/onos-operator/charts/topo-operator/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "topo-operator.fullname" . }}

--- a/onos-operator/charts/topo-operator/values.yaml
+++ b/onos-operator/charts/topo-operator/values.yaml
@@ -1,0 +1,29 @@
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  scope: ""
+  image:
+    registry: ""
+    tag: ""
+
+scope: Cluster
+replicas: 1
+image:
+  registry: ""
+  repository: onosproject/topo-operator
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+logging:
+  loggers:
+    root:
+      level: info
+      output:
+        stdout:
+          sink: stdout
+  sinks:
+    stdout:
+      type: stdout
+      stdout: {}

--- a/onos-operator/charts/topo-operator/values.yaml
+++ b/onos-operator/charts/topo-operator/values.yaml
@@ -12,7 +12,7 @@ replicas: 1
 image:
   registry: ""
   repository: onosproject/topo-operator
-  tag: latest
+  tag: v0.1.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/onos-operator/templates/_helpers.tpl
+++ b/onos-operator/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "onos-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "onos-operator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "onos-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "onos-operator.labels" -}}
+helm.sh/chart: {{ include "onos-operator.chart" . }}
+{{ include "onos-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "onos-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "onos-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+onos-operator image name
+*/}}
+{{- define "onos-operator.imagename" -}}
+{{- if .Values.global.image.registry -}}
+{{- printf "%s/" .Values.global.image.registry -}}
+{{- else if .Values.image.registry -}}
+{{- printf "%s/" .Values.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.image.repository -}}
+{{- if .Values.global.image.tag -}}
+{{- .Values.global.image.tag -}}
+{{- else -}}
+{{- .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+onos-operator scope
+*/}}
+{{- define "onos-operator.scope" -}}
+{{- if .Values.global.scope -}}
+{{- .Values.global.scope | lower -}}
+{{- else if .Values.scope -}}
+{{- .Values.scope | lower -}}
+{{- end -}}
+{{- end -}}

--- a/onos-operator/values.yaml
+++ b/onos-operator/values.yaml
@@ -1,0 +1,15 @@
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "onos-operator"
+
+global:
+  scope: Cluster
+  image:
+    registry: ""
+    tag: ""
+
+config-operator:
+  nameOverride: "config"
+
+topo-operator:
+  nameOverride: "topo"


### PR DESCRIPTION
This PR adds a Helm chart for deploying the onos-operator and its sub-operators for onos-config and onos-topo.