### PR TITLE
Migrate onos-config chart to new model plugins

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: onos-config
-version: 1.0.4
+version: 1.1.0
 kubeVersion: ">=1.17.0"
-appVersion: v0.7.7
+appVersion: v0.7.9
 description: ONOS Config Manager
 keywords:
   - onos

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -23,7 +23,12 @@ spec:
         resource: {{ template "onos-config.fullname" . }}
         {{- include "onos-config.selectorLabels" . | nindent 8 }}
       annotations:
-        "seccomp.security.alpha.kubernetes.io/pod": "unconfined"
+        registry.config.onosproject.org/inject: "true"
+        registry.config.onosproject.org/name: { { template "onos-config.fullname" . } }
+        registry.config.onosproject.org/path: /etc/onos/plugins
+        plugin.config.onosproject.org/api-version: v0.1.0
+        plugin.config.onosproject.org/go-mod-target: github.com/onosproject/onos-config
+        plugin.config.onosproject.org/go-mod-replace: github.com/kuujo/onos-config@6cdca48
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}
@@ -34,21 +39,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        # Run model plugins as init containers to load plugins onto the shared volume
-        {{- range $key, $plugin := .Values.plugins }}
-        - name: {{ printf "config-model-%s-%s" $plugin.name $plugin.version | replace "." "-" }}
-          image: {{ printf "%s:%s" $plugin.image.repository $plugin.image.tag }}
-          imagePullPolicy: {{ $plugin.image.pullPolicy }}
-          command:
-            - "/copylibandstay"
-          args:
-            - {{ printf "%s.so.%s" $plugin.name $plugin.version }}
-            - {{ printf "/usr/local/lib/%s.so.%s" $plugin.name $plugin.version }}
-          volumeMounts:
-            - name: shared-data
-              mountPath: /usr/local/lib
-        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "onos-config.imagename" . | quote }}
@@ -80,9 +70,6 @@ spec:
             - "-caPath=/etc/onos/certs/tls.cacrt"
             - "-keyPath=/etc/onos/certs/tls.key"
             - "-certPath=/etc/onos/certs/tls.crt"
-            {{- range $key, $plugin := .Values.plugins }}
-            - {{ printf "-modelPlugin=/usr/local/lib/shared/%s.so.%s" $plugin.name $plugin.version }}
-              {{- end }}
             {{- if .Values.topoEndpoint }}
             - {{ printf "-topoEndpoint=%s" .Values.topoEndpoint }}
             {{- end }}
@@ -117,8 +104,6 @@ spec:
             - name: secret
               mountPath: /etc/onos/certs
               readOnly: true
-            - name: shared-data
-              mountPath: /usr/local/lib/shared
           # Enable ptrace for debugging
           securityContext:
             {{- if .Values.debug }}
@@ -134,8 +119,6 @@ spec:
         - name: secret
           secret:
             secretName: {{ template "onos-config.fullname" . }}-secret
-        - name: shared-data
-          emptyDir: {}
     {{- with .Values.nodeSelector }}
     nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -23,12 +23,9 @@ spec:
         resource: {{ template "onos-config.fullname" . }}
         {{- include "onos-config.selectorLabels" . | nindent 8 }}
       annotations:
-        registry.config.onosproject.org/inject: "true"
-        registry.config.onosproject.org/name: { { template "onos-config.fullname" . } }
-        registry.config.onosproject.org/path: /etc/onos/plugins
-        plugin.config.onosproject.org/api-version: v0.1.0
-        plugin.config.onosproject.org/go-mod-target: github.com/onosproject/onos-config
-        plugin.config.onosproject.org/go-mod-replace: github.com/kuujo/onos-config@6cdca48
+        registry.config.onosproject.org/inject: {{ template "onos-config.fullname" . }}
+        compiler.config.onosproject.org/version: {{ .Values.plugin.compiler.version | quote }}
+        compiler.config.onosproject.org/target: {{ .Values.plugin.compiler.target | quote }}
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}

--- a/onos-config/templates/modelregistry.yaml
+++ b/onos-config/templates/modelregistry.yaml
@@ -1,0 +1,11 @@
+apiVersion: config.onosproject.org/v1beta1
+kind: ModelRegistry
+metadata:
+  name: {{ template "onos-config.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onos-config.labels" . | nindent 4 }}
+spec:
+  volume:
+    name: {{ template "onos-config.fullname" . }}
+    emptyDir: {}

--- a/onos-config/templates/modelregistry.yaml
+++ b/onos-config/templates/modelregistry.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "onos-config.labels" . | nindent 4 }}
 spec:
-  volume:
+  cache:
     name: {{ template "onos-config.fullname" . }}
     emptyDir: {}

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -31,6 +31,11 @@ devices: []
 # Variable to change to onos topo service endpoint for the default onos-topo:5150
 # topoEndpoint: onos-topo-classic:5150
 
+plugin:
+  compiler:
+    version: v0.1.2
+    target: github.com/onosproject/onos-config@v0.7.9
+
 storage:
   controller: "atomix-controller.kube-system.svc.cluster.local:5679"
   consensus:

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -28,32 +28,6 @@ debug: false
 
 devices: []
 
-plugins:
-  - name: devicesim
-    version: 1.0.0
-    image:
-      repository: onosproject/config-model-devicesim-1.0.0
-      tag: v0.6.20
-      pullPolicy: IfNotPresent
-  - name: stratum
-    version: 1.0.0
-    image:
-      repository: onosproject/config-model-stratum-1.0.0
-      tag: v0.6.20
-      pullPolicy: IfNotPresent
-  - name: testdevice
-    version: 1.0.0
-    image:
-      repository: onosproject/config-model-testdevice-1.0.0
-      tag: v0.6.20
-      pullPolicy: IfNotPresent
-  - name: testdevice
-    version: 2.0.0
-    image:
-      repository: onosproject/config-model-testdevice-2.0.0
-      tag: v0.6.20
-      pullPolicy: IfNotPresent
-
 # Variable to change to onos topo service endpoint for the default onos-topo:5150
 # topoEndpoint: onos-topo-classic:5150
 

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 image:
   registry: ""
   repository: onosproject/onos-config
-  tag: v0.7.7
+  tag: v0.7.9
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
This PR updates the onos-config chart to use the new config operator and model plugin compiler. Model plugins no longer need to be built into Docker images and defined in the onos-config chart's values. Model plugins are extensions to the onos-config API, so the onos-config chart itself doesn't need to know about them. The config operator is now responsible for compiling and loading config model plugins into onos-config pods both at startup time and runtime.