### PR TITLE
Add devicesim config model chart

### DIFF
--- a/config-models/devicesim/.helmignore
+++ b/config-models/devicesim/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/config-models/devicesim/Chart.lock
+++ b/config-models/devicesim/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: config-model-openconfig
-  repository: file://../openconfig
-  version: 1.0.0
-digest: sha256:9fcbf78fd3eee76b89b9ab5ead27a72b328857501559b1618fcdca70d8e2bd68
-generated: "2020-12-15T01:04:50.11115-08:00"

--- a/config-models/devicesim/Chart.lock
+++ b/config-models/devicesim/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: config-model-openconfig
+  repository: file://../openconfig
+  version: 1.0.0
+digest: sha256:9fcbf78fd3eee76b89b9ab5ead27a72b328857501559b1618fcdca70d8e2bd68
+generated: "2020-12-15T01:04:50.11115-08:00"

--- a/config-models/devicesim/Chart.yaml
+++ b/config-models/devicesim/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
     email: support@opennetworking.org
 dependencies:
   - name: config-model-openconfig
-    repository: file://../openconfig
+    repository: https://charts.onosproject.org
     version: 1.0.0

--- a/config-models/devicesim/Chart.yaml
+++ b/config-models/devicesim/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: config-model-devicesim
+version: 1.0.0
+kubeVersion: ">=1.18.0"
+appVersion: 1.0.0
+description: Devicesim model
+keywords:
+  - onos
+  - sdn
+  - config
+home: https://onosproject.org
+maintainers:
+  - name: ONOS Support
+    email: support@opennetworking.org
+dependencies:
+  - name: config-model-openconfig
+    repository: file://../openconfig
+    version: 1.0.0

--- a/config-models/devicesim/templates/_helpers.tpl
+++ b/config-models/devicesim/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "devicesim.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "devicesim.fullname" -}}
+{{- if contains "config-model-devicesim" .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-config-model-devicesim" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "devicesim.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "devicesim.labels" -}}
+helm.sh/chart: {{ include "devicesim.chart" . }}
+{{ include "devicesim.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "devicesim.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "devicesim.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+}

--- a/config-models/devicesim/templates/model.yaml
+++ b/config-models/devicesim/templates/model.yaml
@@ -1,0 +1,14 @@
+apiVersion: config.onosproject.org/v1beta1
+kind: Model
+metadata:
+  name: {{ template "devicesim.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "devicesim.labels" . | nindent 4 }}
+spec:
+  plugin:
+    type: devicesim
+    version: 1.0.0
+  dependencies:
+  - name: {{ template "openconfig.fullname" . }}
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This PR adds a Helm chart defining the devicesim config model. The devicesim chart simply produces a config `Model` from the OpenConfig base model.