### PR TITLE
Using a constant for app label

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.12
+version: 0.1.13
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.6
 description: ONOS cluster

--- a/onos-classic/templates/configmap-init.yaml
+++ b/onos-classic/templates/configmap-init.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-init-scripts
   labels:
-    app: {{ template "fullname" . }}
+    app: onos-classic
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/onos-classic/templates/configmap-logging.yaml
+++ b/onos-classic/templates/configmap-logging.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-logging
   labels:
-    app: {{ template "fullname" . }}
+    app: onos-classic
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/onos-classic/templates/configmap-probe.yaml
+++ b/onos-classic/templates/configmap-probe.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-probe-scripts
   labels:
-    app: {{ template "fullname" . }}
+    app: onos-classic
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/onos-classic/templates/nodeports.yaml
+++ b/onos-classic/templates/nodeports.yaml
@@ -11,7 +11,7 @@ spec:
       port: 8181
       nodePort: {{ .Values.onosApiPort }}
   selector:
-    app: {{ template "fullname" . }}
+    app: onos-classic
   {{- end}}
 ---
   {{- if .Values.onosSshPort }}
@@ -26,7 +26,7 @@ spec:
       port: 8101
       nodePort: {{ .Values.onosSshPort }}
   selector:
-    app: {{ template "fullname" . }}
+    app: onos-classic
   {{- end}}
 
 # workaround for . not working, see

--- a/onos-classic/templates/service.yaml
+++ b/onos-classic/templates/service.yaml
@@ -4,7 +4,8 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}-hs
   labels:
-    app: {{ template "fullname" . }}
+    app: onos-classic
+    name: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -23,5 +24,4 @@ spec:
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
-    app: {{ template "fullname" . }}
-
+    app: onos-classic

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -12,7 +12,8 @@ kind: StatefulSet
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: onos-classic
+    name: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -20,7 +21,7 @@ spec:
   serviceName: {{ template "fullname" . }}-hs
   selector:
     matchLabels:
-      app: {{ template "fullname" . }}
+      app: onos-classic
   replicas: {{ .Values.replicas }}
   updateStrategy:
     type: RollingUpdate
@@ -28,7 +29,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: onos-classic
+        name: {{ template "fullname" . }}
       {{- with .Values.annotations }}
       annotations:
         {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
The `onos-classic` app label changes with each deployment depending on `.Release.Name` this makes it hard to reference the pods using `kubectl -l app=`.

This patch sets the app label to `onos-classic` regardless of the release name for consistency.