### PR TITLE
Update onos-config chart defaults and simplify maintenance

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: onos-config
-version: 1.1.5
+version: 1.1.6
 kubeVersion: ">=1.17.0"
-appVersion: v0.7.11
+appVersion: v0.7.12
 description: ONOS Config Manager
 keywords:
   - onos

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -25,7 +25,11 @@ spec:
       annotations:
         registry.config.onosproject.org/inject: {{ template "onos-config.fullname" . }}
         compiler.config.onosproject.org/version: {{ .Values.plugin.compiler.version | quote }}
+        {{- if .Values.plugin.compiler.target }}
         compiler.config.onosproject.org/target: {{ .Values.plugin.compiler.target | quote }}
+        {{- else }}
+        compiler.config.onosproject.org/target: {{ printf "github.com/onosproject/onos-config@%s" .Values.image.tag | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.annotations }}
         {{ $key }}: {{ $value }}
         {{- end }}

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 image:
   registry: ""
   repository: onosproject/onos-config
-  tag: v0.7.11
+  tag: v0.7.12
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -38,8 +38,8 @@ plugin:
       class: "standard"
       size: 1Gi
   compiler:
-    version: v0.3.1
-    target: github.com/onosproject/onos-config@v0.7.11
+    version: v0.4.0
+    target: ""
 
 storage:
   controller: "atomix-controller.kube-system.svc.cluster.local:5679"


### PR DESCRIPTION
Update the onos-config chart to use the v0.4.0 compiler and use the image tag as the target version by default