### PR TITLE
Aether-2.x - fix plugin name

### DIFF
--- a/config-models/aether-2.x/Chart.yaml
+++ b/config-models/aether-2.x/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: config-model-aether
-version: 2.0.0
+version: 2.0.1
 kubeVersion: ">=1.18.0"
 appVersion: 2.0.0
 description: Aether config model

--- a/config-models/aether-2.x/templates/model.yaml
+++ b/config-models/aether-2.x/templates/model.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "aether.labels" . | nindent 4 }}
 spec:
   plugin:
-    type: aether
+    type: Aether
     version: {{ .Chart.AppVersion | quote }}
   modules:
   - name: aether-subscriber


### PR DESCRIPTION
the name of the plugin should be `Aether` rather than `aether`