### PR TITLE
remove liveliness probes on onos-cli

### DIFF
--- a/onos-cli/Chart.yaml
+++ b/onos-cli/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-cli
 description: ONOS Command Line Interface
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: v0.7.10
 keywords:
   - onos

--- a/onos-cli/templates/deployment.yaml
+++ b/onos-cli/templates/deployment.yaml
@@ -40,18 +40,6 @@ spec:
               mountPath: /home/onos/config
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
tested by deploying in micro-onos environment. observed ready state on pod, and able to talk to e2t.

before change
```
    Liveness:       exec [/bin/sh] delay=5s timeout=1s period=5s #success=1 #failure=3
    Readiness:      exec [/bin/sh] delay=5s timeout=1s period=5s #success=1 #failure=3
Conditions:
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
```

after change
```
kubectl -n micro-onos describe pod onos-cli-bdc95d65c-ztrwd
<snip>
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
<snip>
```

```
kubectl exec -it -n micro-onos $(kubectl -n micro-onos get pods -l type=cli -o name) -- onos e2t list connections
Global ID            PLNM ID   IP Addr           Port    Conn Type
00000000003020f9:0   1279014   192.168.120.163   40145   G_NB
0000000000340422:0   1279014   192.168.120.163   36686   G_NB
```