### PR TITLE
onos-gui: change Nodeport to 31190

### DIFF
--- a/onos-gui/Chart.yaml
+++ b/onos-gui/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-gui
 description: ONOS Graphical User Interface
 kubeVersion: ">=1.15.0"
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: v0.7.2
 keywords:
   - onos

--- a/onos-gui/values.yaml
+++ b/onos-gui/values.yaml
@@ -21,7 +21,7 @@ service:
   name: onos-gui
   type: LoadBalancer
   external:
-    nodePort: 31180
+    nodePort: 31190
 
 ingress:
   enabled: true


### PR DESCRIPTION
Changing NodePort for `onos-gui` from **31180** to **31190** to avoid some other service that seems to have taken over **31180**