### PR TITLE
Correctly selecting PODs for the OpenFlow NodePorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/release
 build/_output
 .DS_Store
 staging/
+requirements.lock
+**/charts/*

--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.14
+version: 0.1.15
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.8
 description: ONOS cluster

--- a/onos-classic/templates/nodeports.yaml
+++ b/onos-classic/templates/nodeports.yaml
@@ -46,6 +46,6 @@ spec:
       port: 6653
       nodePort: {{ add $index 31653 }}
   selector:
-      statefulset.kubernetes.io/pod-name: onos-onos-classic-{{ $index }}
+      statefulset.kubernetes.io/pod-name: {{ template "fullname" $root }}-{{ $index }}
 {{ end }}
 {{- end}}


### PR DESCRIPTION
The `selector` for the OpenFlow `nodePorts` was hardcoded to:
```
selector:
      statefulset.kubernetes.io/pod-name: onos-onos-classic-{{ $index }}
```
That would only work if you install ONOS with release name `onos`.

This patch updates it to use
```
selector:
      statefulset.kubernetes.io/pod-name: {{ template "fullname" $root }}-{{ $index }}
```
so that we can match the statefulset PODs regardless of the name used during the installation