### PR TITLE
Fix the label

### DIFF
--- a/onos-tost/Chart.yaml
+++ b/onos-tost/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-tost
-version: 0.1.27
+version: 0.1.28
 kubeVersion: ">=1.10.0"
 appVersion: stable-2020-12-15
 description: ONOS helm chart for TOST

--- a/onos-tost/requirements.yaml
+++ b/onos-tost/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
 - name: onos-classic
-  version: 0.1.14
+  version: 0.1.16
   repository: https://charts.onosproject.org

--- a/onos-tost/values.yaml
+++ b/onos-tost/values.yaml
@@ -70,7 +70,6 @@ onos-classic:
     replicas: 3
     persistence:
       enabled: false
-  app_label: onos-tost-onos-classic
 
 service_account_name: internal-kubectl
 


### PR DESCRIPTION
Use the `app_label` defined in ONOS classic helm chart to correctly identify the ONOS pods.