### PR TITLE
Use the value for app label instead of hardcode

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.15
+version: 0.1.16
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.8
 description: ONOS cluster

--- a/onos-classic/templates/configmap-init.yaml
+++ b/onos-classic/templates/configmap-init.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-init-scripts
   labels:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/onos-classic/templates/configmap-logging.yaml
+++ b/onos-classic/templates/configmap-logging.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-logging
   labels:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/onos-classic/templates/configmap-probe.yaml
+++ b/onos-classic/templates/configmap-probe.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "fullname" . }}-probe-scripts
   labels:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/onos-classic/templates/nodeports.yaml
+++ b/onos-classic/templates/nodeports.yaml
@@ -11,7 +11,7 @@ spec:
       port: 8181
       nodePort: {{ .Values.onosApiPort }}
   selector:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
   {{- end}}
 ---
   {{- if .Values.onosSshPort }}
@@ -26,7 +26,7 @@ spec:
       port: 8101
       nodePort: {{ .Values.onosSshPort }}
   selector:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
   {{- end}}
 
 # workaround for . not working, see

--- a/onos-classic/templates/service.yaml
+++ b/onos-classic/templates/service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}-hs
   labels:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
     name: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
@@ -24,4 +24,4 @@ spec:
   publishNotReadyAddresses: true
   clusterIP: None
   selector:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -12,7 +12,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: onos-classic
+    app: "{{ .Values.app_label }}"
     name: {{ template "fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
@@ -21,7 +21,7 @@ spec:
   serviceName: {{ template "fullname" . }}-hs
   selector:
     matchLabels:
-      app: onos-classic
+      app: "{{ .Values.app_label }}"
   replicas: {{ .Values.replicas }}
   updateStrategy:
     type: RollingUpdate
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       labels:
-        app: onos-classic
+        app: "{{ .Values.app_label }}"
         name: {{ template "fullname" . }}
       {{- with .Values.annotations }}
       annotations:

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -55,3 +55,5 @@ ports:
 #     log4j2.appender.console.name = Console
 #     log4j2.appender.console.layout.type = PatternLayout
 #     log4j2.appender.console.layout.pattern = %d{RFC3339} %-5level [%c{1}] %msg%n%throwable
+#
+app_label: onos-classic


### PR DESCRIPTION
onos-tost helm chart needs to refer to the `app_label` in the network config pusher. Making this a helm value allows us to refer to it without duplicating.