### PR TITLE
[AETHER-1265] Integrate Java profiler in TOST env

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.16
+version: 0.1.17
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.8
 description: ONOS cluster

--- a/onos-classic/requirements.yaml
+++ b/onos-classic/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
 - name: atomix
-  version: 0.1.5
+  version: 0.1.6
   repository: https://charts.atomix.io

--- a/onos-classic/templates/nodeports.yaml
+++ b/onos-classic/templates/nodeports.yaml
@@ -51,7 +51,7 @@ spec:
 {{- end}}
 
 # Sometimes, it is very hard monitoring or taking the snapshots through the proxy
-{{- if .Values.profiler.enabled }}
+{{- if .Values.profiler.exposeNodePort }}
 {{- $root := . -}}
 {{ range $k, $index := until (atoi (quote .Values.replicas) | default 3) }}
 ---

--- a/onos-classic/templates/nodeports.yaml
+++ b/onos-classic/templates/nodeports.yaml
@@ -49,3 +49,23 @@ spec:
       statefulset.kubernetes.io/pod-name: {{ template "fullname" $root }}-{{ $index }}
 {{ end }}
 {{- end}}
+
+# Sometimes, it is very hard monitoring or taking the snapshots through the proxy
+{{- if .Values.profiler.enabled }}
+{{- $root := . -}}
+{{ range $k, $index := until (atoi (quote .Values.replicas) | default 3) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: onos-profiler-{{ $index }}
+spec:
+  type: NodePort
+  ports:
+    - name: onos-profiler-{{ $index }}
+      port: 10001
+      nodePort: {{ add $index 31004 }}
+  selector:
+      statefulset.kubernetes.io/pod-name: {{ template "fullname" $root }}-{{ $index }}
+{{ end }}
+{{- end}}

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -34,7 +34,7 @@ individualOpenFlowNodePorts: false
 # Adds an additional nodeport to allow profiler connection.
 # When false, profiler can still connect through proxy/port-forward
 profiler:
-  enabled: false
+  exposeNodePort: false
 
 ports:
   - name: openflow

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -31,6 +31,11 @@ resources:
 
 individualOpenFlowNodePorts: false
 
+# Adds an additional nodeport to allow profiler connection.
+# When false, profiler can still connect through proxy/port-forward
+profiler:
+  enabled: false
+
 ports:
   - name: openflow
     port: 6653


### PR DESCRIPTION
Add a nodeport for each onos instance to enable the connection between client and profiler agent.