### PR TITLE
Add Atomix v2beta1 Store and primitives for topo store

### DIFF
--- a/onos-topo/Chart.yaml
+++ b/onos-topo/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-topo
 description: ONOS Topology service
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.0.9
+version: 1.0.10
 appVersion: v0.7.6
 keywords:
   - onos

--- a/onos-topo/templates/_helpers.tpl
+++ b/onos-topo/templates/_helpers.tpl
@@ -67,3 +67,31 @@ onos-topo image name
 {{- .Values.image.tag -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+onos-topo consensus image name
+*/}}
+{{- define "onos-topo.store.consensus.imagename" -}}
+{{- if .Values.global.store.consensus.image.registry -}}
+{{- printf "%s/" .Values.global.store.consensus.image.registry -}}
+{{- else if .Values.store.consensus.image.registry -}}
+{{- printf "%s/" .Values.store.consensus.image.registry -}}
+{{- end -}}
+{{- printf "%s:" .Values.store.consensus.image.repository -}}
+{{- if .Values.global.store.consensus.image.tag -}}
+{{- .Values.global.store.consensus.image.tag -}}
+{{- else -}}
+{{- .Values.store.consensus.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+onos-topo consensus store name
+*/}}
+{{- define "onos-topo.store.consensus.name" -}}
+{{- if .Values.store.consensus.name -}}
+{{- printf "%s" .Values.store.consensus.name -}}
+{{- else -}}
+{{- printf "%s-consensus-store" ( include "onos-topo.fullname" . ) -}}
+{{- end -}}
+{{- end -}}

--- a/onos-topo/templates/configmap.yaml
+++ b/onos-topo/templates/configmap.yaml
@@ -33,4 +33,4 @@ data:
         {{- end }}
       {{- end }}
   logging.yaml: |-
-{{ toYaml .Values.logging | indent 4 }}
+    {{ toYaml .Values.logging | nindent 4 }}

--- a/onos-topo/templates/deployment.yaml
+++ b/onos-topo/templates/deployment.yaml
@@ -23,8 +23,11 @@ spec:
         resource: {{ template "onos-topo.fullname" . }}
         {{- include "onos-topo.selectorLabels" . | nindent 8 }}
       annotations:
-        "seccomp.security.alpha.kubernetes.io/pod": "unconfined"
+        seccomp.security.alpha.kubernetes.io/pod: "unconfined"
+        broker.atomix.io/inject: "true"
+        raft.storage.atomix.io/inject: "true"
     spec:
+      serviceAccountName: {{ template "onos-topo.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}

--- a/onos-topo/templates/primitives.yaml
+++ b/onos-topo/templates/primitives.yaml
@@ -1,0 +1,12 @@
+apiVersion: primitives.atomix.io/v2beta1
+kind: Map
+metadata:
+  name: {{ template "onos-topo.fullname" . }}-objects
+  namespace: {{ .Release.Namespace }}
+spec:
+  store:
+    {{- if .Values.global.store.consensus.enabled }}
+    name: {{ template "global.store.consensus.name" . }}
+    {{- else }}
+    name: {{ template "onos-topo.store.consensus.name" . }}
+    {{- end }}

--- a/onos-topo/templates/role.yaml
+++ b/onos-topo/templates/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: {{ template "onos-topo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - primitives.atomix.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/onos-topo/templates/rolebinding.yaml
+++ b/onos-topo/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "onos-topo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "onos-topo.fullname" . }}
+roleRef:
+  kind: Role
+  name: {{ template "onos-topo.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/onos-topo/templates/serviceaccount.yaml
+++ b/onos-topo/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "onos-topo.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/onos-topo/templates/store.yaml
+++ b/onos-topo/templates/store.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.store.consensus.enabled }}
+apiVersion: atomix.io/v2beta1
+kind: Store
+metadata:
+  name: {{ template "onos-topo.store.consensus.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  protocol:
+    apiVersion: storage.atomix.io/v2beta1
+    kind: MultiRaftProtocol
+    spec:
+      clusters: {{ .Values.store.consensus.clusters }}
+      partitions: {{ .Values.store.consensus.partitions }}
+      replicas: {{ .Values.store.consensus.replicas }}
+      image: {{ template "onos-topo.store.consensus.imagename" . }}
+      imagePullPolicy: {{ .Values.store.consensus.image.pullPolicy }}
+      {{- with .Values.store.consensus.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.store.consensus.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.store.consensus.persistence.storageClass }}
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+          - ReadWriteOnce
+          storageClassName: {{ .Values.store.consensus.persistence.storageClass | quote }}
+          resources:
+            requests:
+              storage: {{ .Values.store.consensus.persistence.storageSize }}
+      {{- end }}
+{{- end }}

--- a/onos-topo/values.yaml
+++ b/onos-topo/values.yaml
@@ -6,6 +6,13 @@ global:
   image:
     registry: ""
     tag: ""
+  store:
+    consensus:
+      name: ""
+      image:
+        registry: ""
+        tag: ""
+  # Deprecated: use 'store' instead
   storage:
     controller: ""
     config:
@@ -26,6 +33,24 @@ fullnameOverride: "onos-topo"
 
 debug: false
 
+store:
+  consensus:
+    enabled: true
+    name: ""
+    image:
+      registry: ""
+      repository: atomix/atomix-raft-storage-node
+      tag: v0.6.6
+      pullPolicy: IfNotPresent
+      pullSecrets: []
+    clusters: 1
+    replicas: 1
+    partitions: 1
+    persistence:
+      storageClass: ""
+      storageSize: 1Gi
+
+# Deprecated: use 'store' instead
 storage:
   controller: "atomix-controller.kube-system.svc.cluster.local:5679"
   consensus:


### PR DESCRIPTION
This PR introduces the Atomix v2beta1 API into the onos-topo chart. This is an intermediate step to migrating the chart to the v2beta1 API. This change runs two data stores -- the v1beta1 database and a v2beta1 store -- side by side, so images prior to and after the upgrade should continue to work.

This change requires that the [Atomix Kubernetes controller](https://github.com/atomix/atomix-controller) and at least one [storage plugin](https://github.com/atomix/atomix-raft-storage-plugin) be installed in the cluster:

```bash
> kubectl create -f https://raw.githubusercontent.com/atomix/atomix-controller/master/deploy/atomix-controller.yaml
> kubectl create -f https://raw.githubusercontent.com/atomix/atomix-raft-storage-plugin/master/deploy/atomix-raft-storage-plugin.yaml
```

The Atomix controller now adds additional resources to Kubernetes API for configuring Atomix primitives. The onos-topo chart includes a `Map` primitive for storing topology objects. Once the chart is installed, you should be able to see the onos-topo-objects primitive in Kubernetes:

```bash
> kubectl get maps
NAME                           STORE
onos-topo-objects              onos-topo-db
```

More importantly, the Atomix v2beta1 API introduces sidecar proxies for operating on primitives. You'll notice that the onos-topo pod spec includes a few new annotations:

* `broker.atomix.io/inject: "true"` injects the Atomix broker into the pod
* `raft.storage.atomix.io/inject: "true"` injects the Raft storage driver (provided by the [Raft storage plugin](https://github.com/atomix/atomix-raft-storage-plugin))

With the current configuration, this means two new containers will be added to the onos-topo pod: the broker and the driver. The broker is a registry of primitives accessible from the pod. Clients query the broker to determine which driver and port to connect to to access a specific primitive. Additional drivers can be injected to adapt primitives to different databases as needed. The use of sidecar proxies to decouple the client code from the underlying protocol removes all the complexity from client libraries and enables Atomix clients to be written in any gRPC-supported language with little effort. The Go client has become little more than a convenient API over gRPC bindings.

Finally, the Atomix v2beta1 API integrates Kubernetes RBAC resources with Atomix primitives. This PR introduces several new RBAC resources to take advantage of the new security features. Currently, onos-topo is assigned broad permission to access any primitive in its namespace. But `Role`s and `ClusterRole`s can be used to enforce much more granular controls as well. Atomix supports read-only permissions for example:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: {{ template "onos-topo.fullname" . }}
rules:
- apiGroups:
  - primitives.atomix.io
  resources:
  - '*'
  verbs:
  - 'read' 
```

Or you can assign permission to read and write a specific primitive or limit a role to a single type of primitive:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: {{ template "onos-topo.fullname" . }}
rules:
- apiGroups:
  - primitives.atomix.io
  resources:
  - 'maps'
  resourceNames:
  - onos-topo-objects
  verbs:
  - 'read'
  - 'write' 
```

The Atomix controller configures proxies within each pod based on the permissions assigned via the Kubernetes RBAC API.