### PR TITLE
dex-ldap-umbrella: upgrading to dex v2.29.0

### DIFF
--- a/dex-ldap-umbrella/Chart.yaml
+++ b/dex-ldap-umbrella/Chart.yaml
@@ -3,7 +3,7 @@ name: dex-ldap-umbrella
 description: Umbrella chart to deploy Dex, OpenLDAP & phpLDAPAdmin
 kubeVersion: ">=1.15.0"
 type: application
-version: 0.1.9
+version: 0.2.0
 appVersion: v0.0.0
 keywords:
   - ldap
@@ -19,8 +19,8 @@ dependencies:
     repository: https://charts.helm.sh/stable
     version: 1.2.7
   - name: dex
-    repository: https://charts.helm.sh/stable
-    version: 2.15.2
+    repository: https://charts.dexidp.io
+    version: 0.5.0
   - name: phpldapadmin
     repository: https://cetic.github.io/helm-charts
     version: 0.1.4

--- a/dex-ldap-umbrella/README.md
+++ b/dex-ldap-umbrella/README.md
@@ -10,7 +10,7 @@ chart that requires an OpenID provider.
 ## Helm install
 Add a couple repos to `helm`, if you don't already have them:
 ```
-helm repo add stable https://charts.helm.sh/stable
+helm repo add dex https://charts.dexidp.io
 helm repo add cetic https://cetic.github.io/helm-charts
 helm repo update
 ```
@@ -26,12 +26,12 @@ It will display details of Port Forwarding that need to be made
 > These details are not given here, as they will vary by namespace.
 
 * Add `dex-ldap-umbrella` to your `/etc/hosts` file as an alias for localhost
-* Port forward the `dex` service to 32000
+* Port forward the `dex` service to 5556
 
-Now GUI applications with security enabled will redirect to this `dex-ldap-umbrella:32000`
+Now GUI applications with security enabled will redirect to this `dex-ldap-umbrella:5556`
 and when login is successful will redirect to an authenticated GUI.
 
-> To test it, browse to http://dex-ldap-umbrella:32000/.well-known/openid-configuration to see the configuration.
+> To test it, browse to http://dex-ldap-umbrella:5556/.well-known/openid-configuration to see the configuration.
 
 
 There are 7 users in 6 groups with the LDIF defined in `values.yaml`
@@ -52,7 +52,7 @@ The password for each is `password`
 
 To use this service with `onos-umbrella` chart, deploy in Helm with the following flags:
 ```
-helm -n micro-onos install onos-umbrella onosproject/onos-umbrella --set onos-config.openidc.issuer=http://dex-ldap-umbrella:32000 --set onos-gui.openidc.issuer=http://dex-ldap-umbrella:32000
+helm -n micro-onos install onos-umbrella onosproject/onos-umbrella --set onos-config.openidc.issuer=http://dex-ldap-umbrella:5556 --set onos-gui.openidc.issuer=http://dex-ldap-umbrella:5556
 ```
 
 ## Adding an organization

--- a/dex-ldap-umbrella/templates/NOTES.txt
+++ b/dex-ldap-umbrella/templates/NOTES.txt
@@ -10,14 +10,14 @@ To learn more about the release, try:
 
 When using Kind set up port-forwarding to expose the services:
 
-To expose Dex at http://dex-ldap-umbrella:32000 run
+To expose Dex at http://dex-ldap-umbrella:{{.Values.dex.service.ports.http.port}} run
 
 DEX_POD_NAME=$(kubectl -n {{.Release.Namespace}} get pods -l "app.kubernetes.io/name=dex,app.kubernetes.io/instance=dex-ldap-umbrella" -o jsonpath="{.items[0].metadata.name}") &&
-kubectl -n {{.Release.Namespace}} port-forward $DEX_POD_NAME 32000:5556
+kubectl -n {{.Release.Namespace}} port-forward $DEX_POD_NAME {{.Values.dex.service.ports.http.port}}:5556
 
 Add `dex-ldap-umbrella` to your `/etc/hosts` file as an alias for `localhost`
 
-To test it, browse to http://dex-ldap-umbrella:32000/.well-known/openid-configuration to see the configuration.
+To test it, browse to http://dex-ldap-umbrella:{{.Values.dex.service.ports.http.port}}/.well-known/openid-configuration to see the configuration.
 
 
 To run the PhpLDAPAdmin tool (optional):

--- a/dex-ldap-umbrella/values.yaml
+++ b/dex-ldap-umbrella/values.yaml
@@ -191,16 +191,20 @@ openldap:
       objectclass: top
 
 dex:
-  ports:
-    grpc:
-      containerPort: 5150
-
-  image: dexidp/dex
-  imageTag: v2.27.0
+  grpc:
+    enabled: true
+  service:
+    ports:
+      http:
+        port: 5556
+      grpc:
+        port: 5150
 
   config:
-    issuer: 'http://dex-ldap-umbrella:32000'
+    issuer: 'http://dex-ldap-umbrella:5556'
 
+    storage:
+      type: memory
     web:
       allowedOrigins: ['*']
 


### PR DESCRIPTION
the older version would not work with Kubernetes `1.21.0`