### PR TITLE
AETHER-2402 Keycloak using roles

### DIFF
--- a/keycloak-389-umbrella/Chart.yaml
+++ b/keycloak-389-umbrella/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak-389-umbrella
 description: Umbrella chart to deploy Keycloak, 389ds & phpLDAPAdmin
 kubeVersion: ">=1.15.0"
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.0.0
 keywords:
   - ldap

--- a/keycloak-389-umbrella/files/keycloak/aether-roc-gui-client.json
+++ b/keycloak-389-umbrella/files/keycloak/aether-roc-gui-client.json
@@ -11,19 +11,17 @@
     "http://localhost:4200/*"
   ],
   "webOrigins": [
-    "http://localhost:8183",
-    "http://localhost:4200",
-    "http://aether-roc-gui:8183"
+    "+"
   ],
   "protocol": "openid-connect",
   "fullScopeAllowed": true,
   "defaultClientScopes": [
     "profile",
-    "email"
+    "email",
+    "roles",
+    "groups"
   ],
   "optionalClientScopes": [
-    "roles",
-    "groups",
     "offline_access"
   ]
 }

--- a/keycloak-389-umbrella/files/keycloak/keycloak-configure.sh
+++ b/keycloak-389-umbrella/files/keycloak/keycloak-configure.sh
@@ -40,7 +40,7 @@ curl -i -X PUT "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}" \
 -H "Authorization: Bearer $TKN" \
 --data-binary "@${KEYCLOAK_PATH}/keycloak-realm-config.json"
 
-curl -i -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes" \
+curl -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/client-scopes" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $TKN" \
 --data-binary "@${KEYCLOAK_PATH}/keycloak-client-scopes-groups.json"
@@ -54,21 +54,30 @@ export COMPONENT_ID=${COMPONENT_ID//[$'\t\r\n']}
 
 echo "Got Component ID $COMPONENT_ID"
 
-curl -i -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/testLDAPConnection" \
+curl -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/testLDAPConnection" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $TKN" \
 --data-raw "$(cat ${KEYCLOAK_PATH}/verify-ldap.json | envsubst)"
 
-curl -i -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/components" \
+curl -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/components" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $TKN" \
 --data-raw "$(cat ${KEYCLOAK_PATH}/keycloak-group-mapper.json | envsubst)"
 
-curl -i -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/user-storage/${COMPONENT_ID}/sync?action=triggerFullSync" \
+curl -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/components" \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer $TKN" \
+--data-raw "$(cat ${KEYCLOAK_PATH}/keycloak-role-mapper.json | envsubst)"
+
+curl -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/user-storage/${COMPONENT_ID}/sync?action=triggerFullSync" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $TKN"
 
-curl -i -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/clients" \
+CLIENT_ID=$(curl -i -X POST "${KEYCLOAK_URL}/admin/realms/${KEYCLOAK_REALM}/clients" \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer $TKN" \
---data-binary "@${KEYCLOAK_PATH}/aether-roc-gui-client.json"
+--data-binary "@${KEYCLOAK_PATH}/aether-roc-gui-client.json" | grep Location | cut -d ' ' -f2 | xargs basename)
+
+export CLIENT_ID=${CLIENT_ID//[$'\t\r\n']}
+echo
+echo "Got Client ID $CLIENT_ID"

--- a/keycloak-389-umbrella/files/keycloak/keycloak-role-mapper.json
+++ b/keycloak-389-umbrella/files/keycloak/keycloak-role-mapper.json
@@ -1,0 +1,38 @@
+{
+  "name": "onf-role-mapper",
+  "providerId": "role-ldap-mapper",
+  "providerType": "org.keycloak.storage.ldap.mappers.LDAPStorageMapper",
+  "parentId": "$COMPONENT_ID",
+  "config": {
+    "mode": [
+      "LDAP_ONLY"
+    ],
+    "membership.attribute.type": [
+      "DN"
+    ],
+    "user.roles.retrieve.strategy": [
+      "LOAD_ROLES_BY_MEMBER_ATTRIBUTE"
+    ],
+    "roles.dn": [
+      "ou=permissions,$LDAP_ORG"
+    ],
+    "membership.user.ldap.attribute": [
+      "uid"
+    ],
+    "membership.ldap.attribute": [
+      "member"
+    ],
+    "memberof.ldap.attribute": [
+      "memberOf"
+    ],
+    "role.name.ldap.attribute": [
+      "cn"
+    ],
+    "use.realm.roles.mapping": [
+      "true"
+    ],
+    "role.object.classes": [
+      "groupOfNames"
+    ]
+  }
+}

--- a/keycloak-389-umbrella/files/ldif/aether-init.ldif
+++ b/keycloak-389-umbrella/files/ldif/aether-init.ldif
@@ -185,6 +185,7 @@ member: uid=elmerf,ou=people,dc=opennetworking,dc=org
 member: uid=fredf,ou=people,dc=opennetworking,dc=org
 member: uid=gandalfg,ou=people,dc=opennetworking,dc=org
 
+# TODO remove this group - add instead as roles as below
 # AetherROCAdmin, groups, opennetworking.org
 dn: cn=AetherROCAdmin,ou=groups,dc=opennetworking,dc=org
 objectClass: top
@@ -195,6 +196,7 @@ cn: AetherROCAdmin
 gidNumber: 503
 member: uid=alicea,ou=people,dc=opennetworking,dc=org
 
+# TODO remove this group - add instead as roles as below
 # EnterpriseAdmin, groups, opennetworking.org
 dn: cn=EnterpriseAdmin,ou=groups,dc=opennetworking,dc=org
 objectClass: top
@@ -206,6 +208,7 @@ gidNumber: 504
 member: uid=daisyd,ou=people,dc=opennetworking,dc=org
 member: uid=fredf,ou=people,dc=opennetworking,dc=org
 
+# Groups - these are enterprises
 # starbucks, groups, opennetworking.org
 dn: cn=starbucks,ou=groups,dc=opennetworking,dc=org
 objectClass: top
@@ -227,3 +230,19 @@ cn: acme
 gidNumber: 511
 member: uid=fredf,ou=people,dc=opennetworking,dc=org
 member: uid=gandalfg,ou=people,dc=opennetworking,dc=org
+
+# Roles - these are permissions
+# EnterpriseAdmin, permissions, opennetworking.org
+dn: cn=EnterpriseAdmin,ou=permissions,dc=opennetworking,dc=org
+objectClass: groupOfNames
+objectClass: top
+cn: EnterpriseAdmin
+member: uid=daisyd,ou=people,dc=opennetworking,dc=org
+member: uid=fredf,ou=people,dc=opennetworking,dc=org
+
+# AetherROCAdmin, permissions, opennetworking.org
+dn: cn=AetherROCAdmin,ou=permissions,dc=opennetworking,dc=org
+objectClass: groupOfNames
+objectClass: top
+cn: AetherROCAdmin
+member: uid=alicea,ou=people,dc=opennetworking,dc=org


### PR DESCRIPTION
This creates an `onf-role-mapper` to drive Keycloak roles, from the `ou=permissions,dc=opennetworking,dc=org` part of the default 389DS installation.

Then the 2 roles `AetherROCAdmin` and `EnterpriseAdmin` are added to LDAP under `ou=permissions` and the user `alicea` added to the former and `daisyd` and `fredf` added to the latter.

In this way `roles` which are about **permission**, are separated from groups which are about **ownership**