### PR TITLE
onos-config: releasing 1.3.9 for v0.9.8 and reverting to config-model v1.0.1

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: onos-config
-version: 1.3.8
+version: 1.3.9
 kubeVersion: ">=1.17.0"
-appVersion: v0.9.7
+appVersion: v0.9.8
 description: ONOS Config Manager
 keywords:
   - onos

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 image:
   registry: ""
   repository: onosproject/onos-config
-  tag: v0.9.7
+  tag: v0.9.8
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -45,7 +45,7 @@ plugin:
       class: "standard"
       size: 1Gi
   compiler:
-    version: v1.0.2
+    version: v1.0.1
     target: ""
 
 store:


### PR DESCRIPTION
There's something with config-model v1.0.2 that causes model plugin loading problems