### PR TITLE
AETHER-2626 start up of keycloak-389-umbrella failures

### DIFF
--- a/keycloak-389-umbrella/Chart.yaml
+++ b/keycloak-389-umbrella/Chart.yaml
@@ -3,7 +3,7 @@ name: keycloak-389-umbrella
 description: Umbrella chart to deploy Keycloak, 389ds & phpLDAPAdmin
 kubeVersion: ">=1.15.0"
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.0.0
 keywords:
   - ldap

--- a/keycloak-389-umbrella/values.yaml
+++ b/keycloak-389-umbrella/values.yaml
@@ -18,7 +18,7 @@ keycloak:
   persistence:
     enabled: false
   directoryManagerPassword: changeme
-  initCommand: sleep 3 && /usr/sbin/dsconf localhost backend create --suffix 'dc=opennetworking,dc=org' --be-name=aether --create-entries --create-suffix > /usr/share/messages
+  initCommand: sleep 3 && (/usr/sbin/dsconf localhost monitor server || /usr/sbin/dsconf localhost backend create --suffix 'dc=opennetworking,dc=org' --be-name=aether --create-entries --create-suffix)
 
 tidyUpPostInstall: true
 


### PR DESCRIPTION
The problem was that the `postStart` hook can be called more than once 
https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-delivery-guarantees 

Now the hook (initCommand) checks if localhost has been created already, and if not creates it