### PR TITLE
Fix: mitigate the issues identified in CVE-2021-44228 by log4j2

### DIFF
--- a/onos-classic/Chart.yaml
+++ b/onos-classic/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: onos-classic
-version: 0.1.25
+version: 0.1.26
 kubeVersion: ">=1.10.0"
 appVersion: 2.2.8
 description: ONOS cluster

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -103,8 +103,6 @@ spec:
         env:
           - name: JAVA_OPTS
             value: {{ .Values.java_opts }}
-          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
-            value: "true"
           {{- with .Values.apps }}
           - name: ONOS_APPS
             value: {{ template "onos-apps" . }}

--- a/onos-classic/templates/statefulset.yaml
+++ b/onos-classic/templates/statefulset.yaml
@@ -103,6 +103,8 @@ spec:
         env:
           - name: JAVA_OPTS
             value: {{ .Values.java_opts }}
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           {{- with .Values.apps }}
           - name: ONOS_APPS
             value: {{ template "onos-apps" . }}

--- a/onos-classic/values.yaml
+++ b/onos-classic/values.yaml
@@ -8,7 +8,7 @@ image:
   pullSecrets: []
 
 replicas: 3
-java_opts: -Xmx4G
+java_opts: -Xmx4G -Dlog4j2.formatMsgNoLookups=true
 probe_timeout: 5
 apps:
 - org.onosproject.openflow-base


### PR DESCRIPTION
as suggested here:
https://www.docker.com/blog/apache-log4j-2-cve-2021-44228/
Also this is overkill as we are building the docker image with java > 11.0.1, thus not being affected as per: https://www.lunasec.io/docs/blog/log4j-zero-day/ 