### PR TITLE
onos-umbrella: Adding REGO rule for Devicesim-1.0.0

### DIFF
--- a/onos-umbrella/Chart.yaml
+++ b/onos-umbrella/Chart.yaml
@@ -3,7 +3,7 @@ name: onos-umbrella
 description: Umbrella chart to deploy all µONOS
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.1.23
+version: 1.1.24
 appVersion: v1.1.0
 keywords:
   - onos

--- a/onos-umbrella/files/opa-rbac/devicesim-1.0.0.rego
+++ b/onos-umbrella/files/opa-rbac/devicesim-1.0.0.rego
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2022-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+
+package devicesim_1_0_0
+
+echo[config] {
+    config := input
+}
+
+
+allowed[config] {
+    interface := interfaces_rule # defer to interfaces rule below
+    system := system_rule
+    config := {
+        "interfaces": {
+            "interface": [
+                interface
+            ]
+        },
+        "system": input.system,
+    }
+}
+
+interfaces_rule[interface] {
+    interface := input.interfaces.interface[_] # for each interface in input
+    ["AetherROCAdmin", interface.name][_] == input.groups[i]
+}
+
+system_rule[system] {
+    system := input.system[_]
+}

--- a/onos-umbrella/files/opa-rbac/testdata/devicesim-1.0.0-example-get.json
+++ b/onos-umbrella/files/opa-rbac/testdata/devicesim-1.0.0-example-get.json
@@ -1,0 +1,36 @@
+{
+  "groups": [
+    "mixedGroup",
+    "acme"
+  ],
+  "system": {
+    "config": {
+      "hostname": "host1",
+      "login-banner": "hello world",
+      "motd-banner": "happy groundhog day!"
+    },
+    "clock": {
+      "config": {
+        "timezone-name": "UTC"
+      }
+    }
+  },
+  "interfaces": {
+    "interface": [
+      {
+        "name": "acme",
+        "config": {
+          "type": "ethernet",
+          "mtu": 1234
+        }
+      },
+      {
+        "name": "eth1",
+        "config": {
+          "type": "ethernet",
+          "mtu": 5678
+        }
+      }
+    ]
+  }
+}

--- a/onos-umbrella/templates/opa-rbac-configmap.yaml
+++ b/onos-umbrella/templates/opa-rbac-configmap.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2022-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-Only-1.0
+
+{{ if ".Values.onos-config.openpolicyagent.enabled" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-opa-rbac
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+{{ (.Files.Glob "files/opa-rbac/*.rego").AsConfig | indent 2 }}
+{{end}}


### PR DESCRIPTION
Just a simple Open Policy Agent Rego Rules for Devicesim-1.0.0

Only `interfaces` whose `name` matches the `group`s that the user is part of will be shown

To see it in action locally do
```bash
opa eval -f pretty -b /home/scondon/go/src/github.com/onosproject/onos-helm-charts/onos-umbrella/files/opa-rbac --input /home/scondon/go/src/github.com/onosproject/onos-helm-charts/onos-umbrella/files/opa-rbac/testdata/devicesim-1.0.0-example-get.json data.devicesim_1_0_0.allowed
```

This can be done inside GoLand using the REGO plugin