### PR TITLE
Add prefix env for plugins

### DIFF
--- a/onos-config/Chart.yaml
+++ b/onos-config/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: onos-config
-version: 1.7.10
+version: 1.7.11
 kubeVersion: ">=1.17.0"
 appVersion: v0.10.38
 description: ONOS Config Manager

--- a/onos-config/templates/deployment.yaml
+++ b/onos-config/templates/deployment.yaml
@@ -165,6 +165,9 @@ spec:
           imagePullPolicy: {{ $root.Values.image.pullPolicy }}
           args:
             - "{{ .port }}"
+          env:
+            - name: PREFIXED
+              value: {{ .prefixed | quote }}
           ports:
             - name: grpc
               containerPort: {{ .port }}

--- a/onos-config/values.yaml
+++ b/onos-config/values.yaml
@@ -56,6 +56,7 @@ modelPlugins:
     endpoint: localhost
     port: 5154
 
+
 # Variable to change to onos topo service endpoint for the default onos-topo:5150
 # topoEndpoint: onos-topo-classic:5150
 

--- a/onos-umbrella/Chart.yaml
+++ b/onos-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-umbrella
 description: Umbrella chart to deploy all µONOS
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.2.43
+version: 1.2.44
 appVersion: v1.1.0
 keywords:
   - onos
@@ -24,7 +24,7 @@ dependencies:
   - name: onos-config
     condition: import.onos-config.enabled
     repository: file://../onos-config
-    version: 1.7.10
+    version: 1.7.11
   - name: onos-gui
     condition: import.onos-gui.enabled
     repository: file://../onos-gui


### PR DESCRIPTION
@SeanCondon  This is the way you have in mind to enable adding prefix at runtime for each plugin? I looked at the code in config models for extracting paths and looks like you don't check the value of PREFIXED env and you just check if it is set or not. Please let me know and I finalize this PR (ignore the new plugin part, that was for my local testing). 